### PR TITLE
CMSimulationGrid is now plugged to the Cormas-UI

### DIFF
--- a/repository/Cormas-Core/CormasModel.class.st
+++ b/repository/Cormas-Core/CormasModel.class.st
@@ -4759,7 +4759,7 @@ CormasModel >> runStep [
 				ifFalse: [self perform: self activeControl].
 			self updateEntities].
 	self channel notNil ifTrue: [self channel flush].
-	self updateDataForChart
+	self updateDataForChart.
 ]
 
 { #category : #deprecated }

--- a/repository/Cormas-UI/CMSimpleChart.class.st
+++ b/repository/Cormas-UI/CMSimpleChart.class.st
@@ -38,7 +38,7 @@ CMSimpleChart class >> openOn: aCMCormasModel [
 	| newBe |
 	newBe := self basicNew.
 	newBe cormasModel: aCMCormasModel.
-	newBe initialize.
+	newBe initializeAndSubscribe.
 	newBe openWithToolbar.
 	^ newBe
 ]
@@ -97,6 +97,13 @@ CMSimpleChart >> cormasModel: anObject [
 
 { #category : #initialization }
 CMSimpleChart >> initialize [
+	| t |
+	super initialize.
+	self addAZeroDataSet
+]
+
+{ #category : #initialization }
+CMSimpleChart >> initializeAndSubscribe [
 	| t |
 	super initialize.
 	self cormasModel announcer

--- a/repository/Cormas-UI/CMSimulationGrid.class.st
+++ b/repository/Cormas-UI/CMSimulationGrid.class.st
@@ -12,6 +12,18 @@ Class {
 	#category : 'Cormas-UI-Core'
 }
 
+{ #category : #'instance creation' }
+CMSimulationGrid class >> openOn: aCMCormasModel [
+	"This method is called by the CMSpecProjectWindow. It creates, subscribes and opens a simulationGrid on a cormasModel"
+
+	| newBe |
+	newBe := self new.
+	newBe initializeOn: aCMCormasModel.
+	newBe subscribeOn: aCMCormasModel.
+	newBe openWithToolbar.
+	^ newBe
+]
+
 { #category : #'model scheduling' }
 CMSimulationGrid >> addNewSituatedEntities [
 	
@@ -173,6 +185,18 @@ anim intervalInMilliseconds: 500
 { #category : #speedOfDisplay }
 CMSimulationGrid >> goSlow [
 anim intervalInMilliseconds: 1000
+]
+
+{ #category : #initialization }
+CMSimulationGrid >> initializeOn: aModel [ 
+	"This method initializes a simulationGrid for a specific cormasModel , without specifyin any animation behaviour"
+
+	model := aModel.
+	self addViewForCells: aModel theESE.
+	self addViewForAgents: aModel allTheSituatedEntities.
+	self canvas camera focusOnCenterScaled.
+	situatedEntitiesViews do: [ :e | e translateTo: e model patch x @ e model patch y * cellSize ].
+
 ]
 
 { #category : #'instance creation' }
@@ -372,4 +396,28 @@ CMSimulationGrid >> situatedEntitiesViews [
 { #category : #accessing }
 CMSimulationGrid >> situatedEntitiesViews: anObject [
 	situatedEntitiesViews := anObject
+]
+
+{ #category : #initialization }
+CMSimulationGrid >> subscribeOn: aModel [ 
+	"This method subscribes the simualtionGrid to the timeChange announcements of a cormasModel.
+	When the simulation time has change, the simulation grid can update it self by calling  self  canvas signalUpdate "
+
+	model announcer
+		subscribe: CMTimeChangedAnnouncement
+			do: [ :aAnnounce | 
+			aAnnounce timeStep = 0
+				ifFalse: [ self timeChanged: aAnnounce timeStep ] ];
+		subscribe: CMSimInitializationAnnouncement do: [ self timeChanged: 0 ].
+
+]
+
+{ #category : #refreshing }
+CMSimulationGrid >> timeChanged: aNewTimeStep [
+
+self removeObsoleteSituatedEntities.
+	self addNewSituatedEntities.
+	situatedEntitiesViews do: [ :e | e translateTo: e model patch x @ e model patch y * cellSize ].
+	self elements do: #updateShape.
+self canvas signalUpdate
 ]

--- a/repository/Cormas-UI/CMSpecProjectWindow.class.st
+++ b/repository/Cormas-UI/CMSpecProjectWindow.class.st
@@ -444,10 +444,12 @@ CMSpecProjectWindow >> openVizProbes [
 
 { #category : #callbacks }
 CMSpecProjectWindow >> openVizSpace [
-
-	CMSpecVizSpaceWindow new 
-		owner: self;
-		openWithSpec.
+		| aModel |
+	aModel := self projectManager cormasModel.
+	aModel spaceModel isNil
+		ifTrue: [ ^ self alertMessage: 'No spaceModel to visualize' ].
+	CMSimulationGrid openOn: aModel
+		
 ]
 
 { #category : #accessing }

--- a/repository/Cormas-UI/CormasModel.extension.st
+++ b/repository/Cormas-UI/CormasModel.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #CormasModel }
 
 { #category : #'*Cormas-UI' }
-CormasModel classSide >> cormasModelName [
+CormasModel class >> cormasModelName [
 
 	^ self asString
 ]


### PR DESCRIPTION
-Use menu Cormas/Vizualization/Space to open a simulationGrid on the current simulation.
-When you run step by step the simulation, the simulationGrid is refreshed. 
- Same  when you run for N steps --> Except that if you run for a lot of step (e.g. more than 50), the synchronization between the model and the simulationGrid  can break, and you get a "red error" message (doesNotUnderstand: #asAthensShapeOn:)