### PR TITLE
rename-x-and-y-to-column-and-line

### DIFF
--- a/repository/Cormas-Core/CMSpatialEntityElement.class.st
+++ b/repository/Cormas-Core/CMSpatialEntityElement.class.st
@@ -1024,16 +1024,22 @@ Example: self wayTo: self spaceModel centralLocation constraint: [:c | c isClose
 	^road
 ]
 
-{ #category : #'+ accessing' }
+{ #category : #'- deprecated' }
 CMSpatialEntityElement >> x [
+	"This method is not supported because numCol is more explicit. Please use numCol instead."
+
 	"Purpose: returns the X coordinate of the cell in a regular spatial grid"
 
+	self deprecated: 'Please use "numCol" instead.'.
 	^ self numCol
 ]
 
-{ #category : #'+ accessing' }
+{ #category : #'- deprecated' }
 CMSpatialEntityElement >> y [
+	"This method is not supported because numCol is more explicit. Please use numCol instead."
+
 	"Purpose: returns the Y coordinate of the cell in a regular spatial grid"
 
+	self deprecated: 'Please use "numLine" instead.'.
 	^ self numLine
 ]

--- a/repository/Cormas-Core/CormasModel.class.st
+++ b/repository/Cormas-Core/CormasModel.class.st
@@ -2284,6 +2284,35 @@ Example: self createFragmentedEntity: UrbanArea fromCollection: (self theCells s
 ]
 
 { #category : #'+ instance creation - spatial grid' }
+CormasModel >> createGridColumns: numColumns lines: numLines neighbourhood: aNumber closed: aBoolean [
+	"Purpose: Create a spatial grid made of cells
+Arguments:  X : number of columns ; Y : number of lines of the grid.
+Arguments: aNumber is the neighbourhood type. It must 4, 6 or 8
+Arguments: aBoolean : closed or torroidal space.
+Example: self createGridX: 20 Y: 20 neighbourhood: 8 closed: true "
+
+	| shapeSymbol nbSymbol |
+	aNumber = 8
+		ifTrue: [ shapeSymbol := #squared.
+			nbSymbol := #eight ].
+	aNumber = 4
+		ifTrue: [ shapeSymbol := #squared.
+			nbSymbol := #four ].
+	aNumber = 6
+		ifTrue: [ shapeSymbol := #hexagonal.
+			nbSymbol := #six ].
+	self spaceModel
+		initializeRegularColumns: numColumns
+		lines: numLines
+		shape: shapeSymbol
+		nbNeighbours: nbSymbol
+		boundaries:
+			(aBoolean
+				ifTrue: [ #closed ]
+				ifFalse: [ #torroidal ])
+]
+
+{ #category : #'+ instance creation - spatial grid' }
 CormasModel >> createGridNeighbourhood: anInteger closed: aBoolean fromMatrixCsvFile: aString attribute: aName [
 	"Purpose: Create a spatial grid made of cells from a csv file in a matrix format providing values for a given attribute.
 The file has to be located into /data folder.
@@ -2294,54 +2323,43 @@ Arguments:
 	anAttributeName <String>: attribute's name.
 
 Example: 	self createGridNeighbourhood: 8 closed: true fromMatrixCsvFile: 'map.csv' attribute: 'cover'. "
-	
+
 	| matrix nbLines nbCols collec |
 	matrix := self readCsvFile: aString.
 	nbLines := matrix size.
 	nbCols := matrix first size.
-	self createGridX: nbCols Y: nbLines neighbourhood: anInteger closed:
-			aBoolean.
+	self
+		createGridColumns: nbCols
+		lines: nbLines
+		neighbourhood: anInteger
+		closed: aBoolean.
 	collec := OrderedCollection new.
-	matrix do: [:line | collec addAll: line].
+	matrix do: [ :line | collec addAll: line ].
 	collec
 		with: self theESE
-		do:
-			[:string :c | 
+		do: [ :string :c | 
 			c
 				perform: (aName , ':') asSymbol
-				with: (Cormas stringAsObjectType: string)]
+				with: (Cormas stringAsObjectType: string) ]
 ]
 
-{ #category : #'+ instance creation - spatial grid' }
+{ #category : #deprecated }
 CormasModel >> createGridX: x Y: y neighbourhood: aNumber closed: aBoolean [
+	"This method is deprecated. Please use createGridColumn:lines:neighbourhood:closed: instead."
 	"Purpose: Create a spatial grid made of cells
 Arguments:  X : number of columns ; Y : number of lines of the grid.
 Arguments: aNumber is the neighbourhood type. It must 4, 6 or 8
 Arguments: aBoolean : closed or torroidal space.
 Example: self createGridX: 20 Y: 20 neighbourhood: 8 closed: true "
-	
-	| shapeSymbol nbSymbol |
-	aNumber = 8
-		ifTrue:
-			[shapeSymbol := #squared.
-			nbSymbol := #eight].
-	aNumber = 4
-		ifTrue:
-			[shapeSymbol := #squared.
-			nbSymbol := #four].
-	aNumber = 6
-		ifTrue:
-			[shapeSymbol := #hexagonal.
-			nbSymbol := #six].
-	self spaceModel
-		initializeRegularX: x
-		Y: y
-		shape: shapeSymbol
-		nbNeighbours: nbSymbol
-		boundaries:
-			(aBoolean
-				ifTrue: [#closed]
-				ifFalse: [#torroidal])
+
+	self
+		deprecated:
+			'This method is no longer supported. Please use createGridColumns:lines:neighbourhood:closed: instead.'.
+	^ self
+		createGridColumns: x
+		lines: y
+		neighbourhood: aNumber
+		closed: aBoolean
 ]
 
 { #category : #'utilities - files' }

--- a/repository/Cormas-Core/CormasModel.class.st
+++ b/repository/Cormas-Core/CormasModel.class.st
@@ -2286,10 +2286,10 @@ Example: self createFragmentedEntity: UrbanArea fromCollection: (self theCells s
 { #category : #'+ instance creation - spatial grid' }
 CormasModel >> createGridColumns: numColumns lines: numLines neighbourhood: aNumber closed: aBoolean [
 	"Purpose: Create a spatial grid made of cells
-Arguments:  X : number of columns ; Y : number of lines of the grid.
+Arguments:  numColumns : number of columns ; numLines : number of lines of the grid.
 Arguments: aNumber is the neighbourhood type. It must 4, 6 or 8
 Arguments: aBoolean : closed or torroidal space.
-Example: self createGridX: 20 Y: 20 neighbourhood: 8 closed: true "
+Example: self createGridColumns: 20 lines: 20 neighbourhood: 8 closed: true "
 
 	| shapeSymbol nbSymbol |
 	aNumber = 8

--- a/repository/Cormas-Core/SpaceModel.class.st
+++ b/repository/Cormas-Core/SpaceModel.class.st
@@ -44,7 +44,7 @@ Class {
 		'absoluteBounds',
 		'autoResizeBounds'
 	],
-	#category : 'Cormas-Core-Space'
+	#category : #'Cormas-Core-Space'
 }
 
 { #category : #'binary storage' }
@@ -2111,7 +2111,25 @@ SpaceModel >> initializeRegular [
 ]
 
 { #category : #'ESE initialize-release' }
+SpaceModel >> initializeRegularColumns: columns lines: lines shape: shapeSymbol nbNeighbours: nbSymbol boundaries: bSymbol [
+	"Create a grid of regular cells.
+lines = number of lines. columns = number of columns.
+shapeSymbol =<Symbol> (#squared , )
+nbSymbol =<Symbol> (#four, #six or #eight)
+bSymbol = <Symbol> (#toroidal or #closed) .
+ex, from CormasModel:
+	self spaceModel initializeRegularColumns: 101 lines: 101 shape: #squared nbNeighbours: #eight boundaries: #toroidal."
+	
+	self resetSpatialEntities.
+	self line: lines column: columns shape: shapeSymbol nbNeighbours: nbSymbol
+		boundaries: bSymbol.
+	self createCells
+]
+
+{ #category : #deprecated }
 SpaceModel >> initializeRegularX: columns Y: lines shape: shapeSymbol nbNeighbours: nbSymbol boundaries: bSymbol [
+	"This method is deprecated. Please use initializeRegularColumns:lines:shape:nbNeighbours:boundaries: instead."
+
 	"Create a grid of regular cells.
 lines = number of lines. columns = number of columns.
 shapeSymbol =<Symbol> (#squared , )
@@ -2119,11 +2137,16 @@ nbSymbol =<Symbol> (#four, #six or #eight)
 bSymbol = <Symbol> (#toroidal or #closed) .
 ex, from CormasModel:
 	self spaceModel initializeRegularX: 101 Y: 101 shape: #squared nbNeighbours: #eight boundaries: #toroidal."
-	
-	self resetSpatialEntities.
-	self line: lines column: columns shape: shapeSymbol nbNeighbours: nbSymbol
-		boundaries: bSymbol.
-	self createCells
+
+	self
+		deprecated:
+			'This method is no longer supported. Please use initializeRegularColumns:lines:shape:nbNeighbours:boundaries: instead.'.
+	^ self
+		initializeRegularColumns: columns
+		lines: lines
+		shape: shapeSymbol
+		nbNeighbours: nbSymbol
+		boundaries: bSymbol
 ]
 
 { #category : #'private - init' }
@@ -4085,22 +4108,20 @@ SpaceModel >> setSpatialEntitiesAttributsValueFromStream: aStream [
 
 { #category : #'- utilities - binary storage' }
 SpaceModel >> settingsFrom: aClone [
-	
 	(self absoluteBounds = aClone absoluteBounds
-		and:
-			[self column = aClone column
-				and:
-					[self line = aClone line and: [self nbNeighbours = aClone nbNeighbours]]])
-		ifTrue: [aClone isIrregular ifFalse: [^self]].
+		and: [ self column = aClone column
+				and: [ self line = aClone line
+						and: [ self nbNeighbours = aClone nbNeighbours ] ] ])
+		ifTrue: [ aClone isIrregular
+				ifFalse: [ ^ self ] ].
 	self autoResizeBounds: aClone autoResizeBounds.
 	aClone isIrregular
-		ifFalse:
-			[self
-				initializeRegularX: aClone column
-				Y: aClone line
+		ifFalse: [ self
+				initializeRegularColumns: aClone column
+				lines: aClone line
 				shape: aClone gridCellShape
 				nbNeighbours: aClone nbNeighbours
-				boundaries: aClone boundaries]
+				boundaries: aClone boundaries ]
 ]
 
 { #category : #'landscape indices' }

--- a/repository/Cormas-Model-Conway/CMConwayModel.class.st
+++ b/repository/Cormas-Model-Conway/CMConwayModel.class.st
@@ -15,7 +15,7 @@ Class {
 	#instVars : [
 		'theCMConwayCells'
 	],
-	#category : 'Cormas-Model-Conway'
+	#category : #'Cormas-Model-Conway'
 }
 
 { #category : #default }
@@ -42,8 +42,8 @@ CMConwayModel class >> example1 [
 	nbLines := 50.
 	aModel initializeSpaceModel.
 	aModel
-		createGridX: nbLines
-		Y: nbLines
+		createGridColumns: nbLines
+		lines: nbLines
 		neighbourhood: 4
 		closed: true.
 	v := RTView new.
@@ -68,7 +68,7 @@ CMConwayModel class >> example1 [
 		blockToExecute: [ aModel runStep.
 			v elements do: #updateShape ].
 	anim inView: v.
-	v openWithToolbar  
+	v openWithToolbar
 ]
 
 { #category : #examples }
@@ -85,8 +85,8 @@ CMConwayModel class >> example2 [
 				new.
 			aModel initializeSpaceModel.
 			aModel
-				createGridX: nbLines
-				Y: nbLines
+				createGridColumns: nbLines
+				lines: nbLines
 				neighbourhood: 4
 				closed: true.
 			aModel initSimulation.
@@ -130,8 +130,8 @@ CMConwayModel class >> example3 [
 	nbLines := 100.
 	aModel initializeSpaceModel.
 	aModel
-		createGridX: nbLines
-		Y: nbLines
+		createGridColumns: nbLines
+		lines: nbLines
 		neighbourhood: 4
 		closed: true.
 	v := RTView new.
@@ -242,16 +242,19 @@ CMConwayModel >> initGlidersGun [
 
 { #category : #init }
 CMConwayModel >> initRandomly [
-	
-	self createGridX: 100 Y: 100 neighbourhood: 8 closed: true.
+	self
+		createGridColumns: 100
+		lines: 100
+		neighbourhood: 8
+		closed: true.
 	self initCells: #initRandomly
 ]
 
 { #category : #init }
 CMConwayModel >> initSmallGrid [
 	self
-		createGridX: 10
-		Y: 10
+		createGridColumns: 10
+		lines: 10
 		neighbourhood: 4
 		closed: false.
 	self initCells: #initRandomly

--- a/repository/Cormas-Model-ECEC/CMECECModel.class.st
+++ b/repository/Cormas-Model-ECEC/CMECECModel.class.st
@@ -9,7 +9,7 @@ Class {
 		'theCMECECVegetationUnits',
 		'theRestraineds'
 	],
-	#category : 'Cormas-Model-ECEC'
+	#category : #'Cormas-Model-ECEC'
 }
 
 { #category : #'- probes' }
@@ -441,18 +441,27 @@ CMECECModel >> homogeneousEnv [
 	"initialize an homogeneous space (from poor.env file) with randomly located foragers"
 
 	"self spaceModel loadEnvironmentFromFile: 'poor.env'."
-	self createGridX: 15 Y: 27 neighbourhood: 8 closed: true.
-	self theCMECECVegetationUnits do: [ :c |  c initRandomBiomass].
+
+	self
+		createGridColumns: 15
+		lines: 27
+		neighbourhood: 8
+		closed: true.
+	self theCMECECVegetationUnits do: [ :c | c initRandomBiomass ].
 	self initAgents
 ]
 
 { #category : #'instance-creation' }
 CMECECModel >> homogeneousEnv2 [
 	"initialize an homogeneous space (27x27, random biomass) with randomly located foragers"
-	
-	self spaceModel initializeRegularX: 27 Y: 27 shape: #squared nbNeighbours:
-			#eight boundaries: #toroidal.
-	self theCMECECVegetationUnits do: [:cell | cell initRandomBiomass].	"or: self initCells: #initRandomBiomass."
+
+	self spaceModel
+		initializeRegularColumns: 27
+		lines: 27
+		shape: #squared
+		nbNeighbours: #eight
+		boundaries: #toroidal.
+	self theCMECECVegetationUnits do: [ :cell | cell initRandomBiomass ].	"or: self initCells: #initRandomBiomass."
 	self initAgents
 ]
 

--- a/repository/Cormas-Model-FireAutomata/CMFireAutomataModel.class.st
+++ b/repository/Cormas-Model-FireAutomata/CMFireAutomataModel.class.st
@@ -27,7 +27,7 @@ Class {
 	#classInstVars : [
 		'defaultInit'
 	],
-	#category : 'Cormas-Model-FireAutomata'
+	#category : #'Cormas-Model-FireAutomata'
 }
 
 { #category : #examples }
@@ -76,12 +76,11 @@ CMFireAutomataModel class >> example1 [
 	nbLines := 100.
 	aModel initializeSpaceModel.
 	aModel
-		createGridX: nbLines
-		Y: nbLines
+		createGridColumns: nbLines
+		lines: nbLines
 		neighbourhood: 4
 		closed: true.
 	v := RTView new.
-	
 	aModel activeInit: #init58WithFire.
 	aModel initSimulation.
 	aModel runStep.
@@ -434,14 +433,12 @@ CMFireAutomataModel class >> simuOpenMole2 [
 
 { #category : #'programmable scenario' }
 CMFireAutomataModel >> dimensions: aPair [
-
 	self initializeSpaceModel.
-
 	self
-		createGridX: aPair key
-		Y: aPair value
+		createGridColumns: aPair key
+		lines: aPair value
 		neighbourhood: 4
-		closed: true.
+		closed: true
 ]
 
 { #category : #description }
@@ -457,15 +454,23 @@ CMFireAutomataModel >> init53 [
 
 { #category : #init }
 CMFireAutomataModel >> init53WithFire [
-	self createGridX: 80 Y: 80 neighbourhood: 4 closed: false.
+	self
+		createGridColumns: 80
+		lines: 80
+		neighbourhood: 4
+		closed: false.
 	self initCells: #init53.
-	self pickCell state: #fire.
+	self pickCell state: #fire
 ]
 
 { #category : #init }
 CMFireAutomataModel >> init58 [
-	self createGridX: 80 Y: 80 neighbourhood: 4 closed: false.
-	self initCells: #init58.
+	self
+		createGridColumns: 80
+		lines: 80
+		neighbourhood: 4
+		closed: false.
+	self initCells: #init58
 ]
 
 { #category : #init }
@@ -477,13 +482,18 @@ CMFireAutomataModel >> init58WithFire [
 { #category : #init }
 CMFireAutomataModel >> init58WithFireWithFiremen [
 	| aCell |
-	self createGridX: 80 Y: 80 neighbourhood: 4 closed: false.
+	self
+		createGridColumns: 80
+		lines: 80
+		neighbourhood: 4
+		closed: false.
 	self initCells: #init58.
-	1 to: self numberOfFires do: [:i | 
-			aCell :=  self pickCell.
-			aCell = nil ifTrue:[self halt].
-			aCell state: #fire].
-	self initAgents.
+	1 to: self numberOfFires do: [ :i | 
+		aCell := self pickCell.
+		aCell = nil
+			ifTrue: [ self halt ].
+		aCell state: #fire ].
+	self initAgents
 ]
 
 { #category : #init }
@@ -506,8 +516,8 @@ CMFireAutomataModel >> initAgents [
 CMFireAutomataModel >> initSmallWithFireWithFiremen [
 	| aCell |
 	self
-		createGridX: 40
-		Y: 40
+		createGridColumns: 40
+		lines: 40
 		neighbourhood: 4
 		closed: false.
 	self initCells: #init58.
@@ -522,13 +532,18 @@ CMFireAutomataModel >> initSmallWithFireWithFiremen [
 { #category : #init }
 CMFireAutomataModel >> initWithFiremen [
 	| aCell |
-	self createGridX: 80 Y: 80 neighbourhood: 4 closed: false.
+	self
+		createGridColumns: 80
+		lines: 80
+		neighbourhood: 4
+		closed: false.
 	self initCells: #initWith: withArguments: {60}.
-	1 to: self numberOfFires do: [:i | 
-			aCell :=  self pickCell.
-			aCell = nil ifTrue:[self halt].
-			aCell state: #fire].
-	self initAgents.
+	1 to: self numberOfFires do: [ :i | 
+		aCell := self pickCell.
+		aCell = nil
+			ifTrue: [ self halt ].
+		aCell state: #fire ].
+	self initAgents
 ]
 
 { #category : #'programmable scenario' }

--- a/repository/Cormas-Model-FireAutomata/CMFireAutomataModelTest.class.st
+++ b/repository/Cormas-Model-FireAutomata/CMFireAutomataModelTest.class.st
@@ -14,8 +14,8 @@ CMFireAutomataModelTest >> testDominanceOfAModelIsLessThanOne [
 	aModel class defaultInit: #init58WithFire.
 	aModel initializeSpaceModel.
 	aModel
-		createGridX: 100
-		Y: 100
+		createGridColumns: 100
+		lines: 100
 		neighbourhood: 4
 		closed: true.
 	aModel initSimulation.
@@ -39,10 +39,10 @@ CMFireAutomataModelTest >> testNumberOfDifferentStateInAFireAutomataIsThree [
 	aModel class defaultInit: #init58WithFire.
 	aModel initializeSpaceModel.
 	aModel
-		createGridX: 10
-		Y: 10
+		createGridColumns: 10
+		lines: 10
 		neighbourhood: 4
-		closed: true.		
+		closed: true.
 	aModel initSimulation.
 	self assert: (aModel nbDistinctValuesOf: #state) equals: 3
 ]
@@ -56,8 +56,8 @@ CMFireAutomataModelTest >> testSizeOfCellsColumnOfFireAutomataModelIsTen [
 		new.
 	aModel initializeSpaceModel.
 	aModel
-		createGridX: 10
-		Y: 10
+		createGridColumns: 10
+		lines: 10
 		neighbourhood: 4
 		closed: true.
 	aModel activeInit: #init58WithFire.
@@ -74,8 +74,8 @@ CMFireAutomataModelTest >> testWhenAfterRunningTheModel20TimesTheProbesResultHav
 	aModel := modelClass new.
 	aModel initializeSpaceModel.
 	aModel
-		createGridX: 100
-		Y: 100
+		createGridColumns: 100
+		lines: 100
 		neighbourhood: 4
 		closed: true.
 	nbSteps := 20.
@@ -97,8 +97,8 @@ CMFireAutomataModelTest >> testWhenYouPickACellOfAModelThisIsASpatialEntity [
 	aModel := modelClass new.
 	aModel initializeSpaceModel.
 		aModel
-		createGridX: 100
-		Y: 100
+		createGridColumns: 100
+		lines: 100
 		neighbourhood: 4
 		closed: true.
 	aModel initSimulation.

--- a/repository/Cormas-Model-PlotsRental/CMPlotsRentalModel.class.st
+++ b/repository/Cormas-Model-PlotsRental/CMPlotsRentalModel.class.st
@@ -336,9 +336,9 @@ CMPlotsRentalModel >> initAgentsAuctioneer [
 CMPlotsRentalModel >> initCells [
 	"10x10 cells"
 
-	self 
-		createGridX: 10
-		Y: 10
+	self
+		createGridColumns: 10
+		lines: 10
 		neighbourhood: 8
 		closed: true
 ]

--- a/repository/Cormas-Tests/CormasModelTest.class.st
+++ b/repository/Cormas-Tests/CormasModelTest.class.st
@@ -13,8 +13,8 @@ CormasModelTest >> testCentralCell [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 3
-			Y: 3
+		createGridColumns: 3
+			lines: 3
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -32,8 +32,8 @@ CormasModelTest >> testCreateGridXYNeighborHoodClosed [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -51,8 +51,8 @@ CormasModelTest >> testDominance [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 100
-			Y: 100
+		createGridColumns: 100
+			lines: 100
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -69,8 +69,8 @@ CormasModelTest >> testDominance1 [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 100
-			Y: 100
+		createGridColumns: 100
+			lines: 100
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -86,8 +86,8 @@ CormasModelTest >> testLowerLeftCell [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 3
-			Y: 3
+		createGridColumns: 3
+			lines: 3
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -105,8 +105,8 @@ CormasModelTest >> testLowerRightCell [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 3
-			Y: 3
+		createGridColumns: 3
+			lines: 3
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -124,8 +124,8 @@ CormasModelTest >> testNbDistinctValuesOf [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -145,15 +145,15 @@ CormasModelTest >> testPickCell [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
 	cell := model pickCell.
 	self assert: cell isSpatialEntity.
-	self assert: (cell x between: 1 and: 10).
-	self assert: (cell y between: 1 and: 20)
+	self assert: (cell numCol between: 1 and: 10).
+	self assert: (cell numLine between: 1 and: 20)
 ]
 
 { #category : #'tests-accessing-entities' }
@@ -165,8 +165,8 @@ CormasModelTest >> testPickCellConstrainedBy [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 9
-			Y: 9
+		createGridColumns: 9
+			lines: 9
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -189,8 +189,8 @@ CormasModelTest >> testPickCellWithoutAny [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation;
@@ -210,8 +210,8 @@ CormasModelTest >> testPickCellsN [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -228,8 +228,8 @@ CormasModelTest >> testPickEntity [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -245,25 +245,28 @@ CormasModelTest >> testPickEntityConstrainedBy [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
 	self
 		assert:
-			(model pickEntity: CMCellForTest constrainedBy: [ :cell | cell x = 3 ])
-				x
+			(model
+				pickEntity: CMCellForTest
+				constrainedBy: [ :cell | cell numCol = 3 ]) numCol
 		equals: 3.
 	self
 		assert:
-			(model pickEntity: CMCellForTest constrainedBy: [ :cell | cell x = 6 ])
-				x
+			(model
+				pickEntity: CMCellForTest
+				constrainedBy: [ :cell | cell numCol = 6 ]) numCol
 		equals: 6.
 	self
 		assert:
-			(model pickEntity: CMCellForTest constrainedBy: [ :cell | cell x = 9 ])
-				x
+			(model
+				pickEntity: CMCellForTest
+				constrainedBy: [ :cell | cell numCol = 9 ]) numCol
 		equals: 9
 ]
 
@@ -276,8 +279,8 @@ CormasModelTest >> testPickNEntities [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -295,8 +298,8 @@ CormasModelTest >> testPickNEntitiesConstrainedBy [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -305,8 +308,8 @@ CormasModelTest >> testPickNEntitiesConstrainedBy [
 			((model
 				pickN: 5
 				entities: CMCellForTest
-				constrainedBy: [ :cell | cell x = 5 ])
-				allSatisfy: [ :cell | cell x = 5 ])
+				constrainedBy: [ :cell | cell numCol = 5 ])
+				allSatisfy: [ :cell | cell numCol = 5 ])
 ]
 
 { #category : #'tests-accessing-entities' }
@@ -318,8 +321,8 @@ CormasModelTest >> testPickUnoccupiedCell [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation;
@@ -343,8 +346,8 @@ CormasModelTest >> testSelectCellsInRectangle [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -352,8 +355,8 @@ CormasModelTest >> testSelectCellsInRectangle [
 	self assert: cells size equals: 9.
 	cells
 		do: [ :cell | 
-			self assert: (cell x between: 5 and: 7).
-			self assert: (cell y between: 5 and: 7) ]
+			self assert: (cell numCol between: 5 and: 7).
+			self assert: (cell numLine between: 5 and: 7) ]
 ]
 
 { #category : #'tests-accessing-entities' }
@@ -365,8 +368,8 @@ CormasModelTest >> testSelectCellsInRectangleOriginCellCornerCell [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 5
-			Y: 9
+		createGridColumns: 5
+			lines: 9
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -376,8 +379,8 @@ CormasModelTest >> testSelectCellsInRectangleOriginCellCornerCell [
 	self assert: cells size equals: 15.
 	cells
 		do: [ :cell | 
-			self assert: (cell x between: 1 and: 3).
-			self assert: (cell y between: 1 and: 5) ]
+			self assert: (cell numCol between: 1 and: 3).
+			self assert: (cell numLine between: 1 and: 5) ]
 ]
 
 { #category : #'tests-accessing-entities' }
@@ -389,8 +392,8 @@ CormasModelTest >> testSelectCellsOfColumn [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -411,8 +414,8 @@ CormasModelTest >> testSelectCellsOfLine [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -456,8 +459,8 @@ CormasModelTest >> testTheAgents [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 10
-			Y: 20
+		createGridColumns: 10
+			lines: 20
 			neighbourhood: 4
 			closed: true;
 		initSimulation;
@@ -478,8 +481,8 @@ CormasModelTest >> testUpperLeftCell [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 3
-			Y: 3
+		createGridColumns: 3
+			lines: 3
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -497,8 +500,8 @@ CormasModelTest >> testUpperRightCell [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridX: 3
-			Y: 3
+		createGridColumns: 3
+			lines: 3
 			neighbourhood: 4
 			closed: true;
 		initSimulation.


### PR DESCRIPTION
deprecate x and y of CMSpatialEntityElement and transform their senders to use numCol and numLine