### PR TITLE
129-x-and-y-in-method-names-should-be-column-and-line

### DIFF
--- a/repository/Cormas-Core/CMSpaceModel.class.st
+++ b/repository/Cormas-Core/CMSpaceModel.class.st
@@ -2097,7 +2097,7 @@ CMSpaceModel >> initializeRegular [
 ]
 
 { #category : #'ESE initialize-release' }
-CMSpaceModel >> initializeRegularColumns: columns lines: lines shape: shapeSymbol nbNeighbours: nbSymbol boundaries: bSymbol [
+CMSpaceModel >> initializeRegularLines: lines columns: columns shape: shapeSymbol nbNeighbours: nbSymbol boundaries: bSymbol [
 	"Create a grid of regular cells.
 lines = number of lines. columns = number of columns.
 shapeSymbol =<Symbol> (#squared , )
@@ -2128,8 +2128,8 @@ ex, from CormasModel:
 		deprecated:
 			'This method is no longer supported. Please use initializeRegularColumns:lines:shape:nbNeighbours:boundaries: instead.'.
 	^ self
-		initializeRegularColumns: columns
-		lines: lines
+		initializeRegularLines: lines
+		columns: columns
 		shape: shapeSymbol
 		nbNeighbours: nbSymbol
 		boundaries: bSymbol
@@ -4077,8 +4077,8 @@ CMSpaceModel >> settingsFrom: aClone [
 	self autoResizeBounds: aClone autoResizeBounds.
 	aClone isIrregular
 		ifFalse: [ self
-				initializeRegularColumns: aClone column
-				lines: aClone line
+				initializeRegularLines: aClone line
+				columns: aClone column
 				shape: aClone gridCellShape
 				nbNeighbours: aClone nbNeighbours
 				boundaries: aClone boundaries ]

--- a/repository/Cormas-Core/CormasModel.class.st
+++ b/repository/Cormas-Core/CormasModel.class.st
@@ -2225,7 +2225,7 @@ Example: self createFragmentedEntity: UrbanArea fromCollection: (self theCells s
 ]
 
 { #category : #'+ instance creation - spatial grid' }
-CormasModel >> createGridColumns: numColumns lines: numLines neighbourhood: aNumber closed: aBoolean [
+CormasModel >> createGridLines: numLines columns: numColumns neighbourhood: aNumber closed: aBoolean [
 	"Purpose: Create a spatial grid made of cells
 Arguments:  numColumns : number of columns ; numLines : number of lines of the grid.
 Arguments: aNumber is the neighbourhood type. It must 4, 6 or 8
@@ -2243,8 +2243,8 @@ Example: self createGridColumns: 20 lines: 20 neighbourhood: 8 closed: true "
 		ifTrue: [ shapeSymbol := #hexagonal.
 			nbSymbol := #six ].
 	self spaceModel
-		initializeRegularColumns: numColumns
-		lines: numLines
+		initializeRegularLines: numLines
+		columns: numColumns
 		shape: shapeSymbol
 		nbNeighbours: nbSymbol
 		boundaries:
@@ -2270,8 +2270,8 @@ Example: 	self createGridNeighbourhood: 8 closed: true fromMatrixCsvFile: 'map.c
 	nbLines := matrix size.
 	nbCols := matrix first size.
 	self
-		createGridColumns: nbCols
-		lines: nbLines
+		createGridLines: nbLines
+		columns: nbCols
 		neighbourhood: anInteger
 		closed: aBoolean.
 	collec := OrderedCollection new.
@@ -2287,6 +2287,7 @@ Example: 	self createGridNeighbourhood: 8 closed: true fromMatrixCsvFile: 'map.c
 { #category : #deprecated }
 CormasModel >> createGridX: x Y: y neighbourhood: aNumber closed: aBoolean [
 	"This method is deprecated. Please use createGridColumn:lines:neighbourhood:closed: instead."
+
 	"Purpose: Create a spatial grid made of cells
 Arguments:  X : number of columns ; Y : number of lines of the grid.
 Arguments: aNumber is the neighbourhood type. It must 4, 6 or 8
@@ -2297,8 +2298,8 @@ Example: self createGridX: 20 Y: 20 neighbourhood: 8 closed: true "
 		deprecated:
 			'This method is no longer supported. Please use createGridColumns:lines:neighbourhood:closed: instead.'.
 	^ self
-		createGridColumns: x
-		lines: y
+		createGridLines: y
+		columns: x
 		neighbourhood: aNumber
 		closed: aBoolean
 ]

--- a/repository/Cormas-Model-Conway/CMConwayModel.class.st
+++ b/repository/Cormas-Model-Conway/CMConwayModel.class.st
@@ -42,8 +42,8 @@ CMConwayModel class >> example1 [
 	nbLines := 50.
 	aModel initializeSpaceModel.
 	aModel
-		createGridColumns: nbLines
-		lines: nbLines
+		createGridLines: nbLines
+		columns: nbLines
 		neighbourhood: 4
 		closed: true.
 	v := RTView new.
@@ -85,8 +85,8 @@ CMConwayModel class >> example2 [
 				new.
 			aModel initializeSpaceModel.
 			aModel
-				createGridColumns: nbLines
-				lines: nbLines
+				createGridLines: nbLines
+				columns: nbLines
 				neighbourhood: 4
 				closed: true.
 			aModel initSimulation.
@@ -130,8 +130,8 @@ CMConwayModel class >> example3 [
 	nbLines := 100.
 	aModel initializeSpaceModel.
 	aModel
-		createGridColumns: nbLines
-		lines: nbLines
+		createGridLines: nbLines
+		columns: nbLines
 		neighbourhood: 4
 		closed: true.
 	v := RTView new.
@@ -243,8 +243,8 @@ CMConwayModel >> initGlidersGun [
 { #category : #init }
 CMConwayModel >> initRandomly [
 	self
-		createGridColumns: 100
-		lines: 100
+		createGridLines: 100
+		columns: 100
 		neighbourhood: 8
 		closed: true.
 	self initCells: #initRandomly
@@ -253,8 +253,8 @@ CMConwayModel >> initRandomly [
 { #category : #init }
 CMConwayModel >> initSmallGrid [
 	self
-		createGridColumns: 10
-		lines: 10
+		createGridLines: 10
+		columns: 10
 		neighbourhood: 4
 		closed: false.
 	self initCells: #initRandomly

--- a/repository/Cormas-Model-ECEC/CMECECModel.class.st
+++ b/repository/Cormas-Model-ECEC/CMECECModel.class.st
@@ -485,8 +485,8 @@ CMECECModel >> homogeneousEnv [
 	"self spaceModel loadEnvironmentFromFile: 'poor.env'."
 
 	self
-		createGridColumns: 15
-		lines: 27
+		createGridLines: 27
+		columns: 15
 		neighbourhood: 8
 		closed: true.
 	self theCMECECVegetationUnits do: [ :c | c initRandomBiomass ].
@@ -498,8 +498,8 @@ CMECECModel >> homogeneousEnv2 [
 	"initialize an homogeneous space (27x27, random biomass) with randomly located foragers"
 
 	self spaceModel
-		initializeRegularColumns: 27
-		lines: 27
+		initializeRegularLines: 27
+		columns: 27
 		shape: #squared
 		nbNeighbours: #eight
 		boundaries: #toroidal.

--- a/repository/Cormas-Model-FireAutomata/CMFireAutomataModel.class.st
+++ b/repository/Cormas-Model-FireAutomata/CMFireAutomataModel.class.st
@@ -76,8 +76,8 @@ CMFireAutomataModel class >> example1 [
 	nbLines := 100.
 	aModel initializeSpaceModel.
 	aModel
-		createGridColumns: nbLines
-		lines: nbLines
+		createGridLines: nbLines
+		columns: nbLines
 		neighbourhood: 4
 		closed: true.
 	v := RTView new.
@@ -435,8 +435,8 @@ CMFireAutomataModel class >> simuOpenMole2 [
 CMFireAutomataModel >> dimensions: aPair [
 	self initializeSpaceModel.
 	self
-		createGridColumns: aPair key
-		lines: aPair value
+		createGridLines: aPair value
+		columns: aPair key
 		neighbourhood: 4
 		closed: true
 ]
@@ -455,8 +455,8 @@ CMFireAutomataModel >> init53 [
 { #category : #init }
 CMFireAutomataModel >> init53WithFire [
 	self
-		createGridColumns: 80
-		lines: 80
+		createGridLines: 80
+		columns: 80
 		neighbourhood: 4
 		closed: false.
 	self initCells: #init53.
@@ -466,8 +466,8 @@ CMFireAutomataModel >> init53WithFire [
 { #category : #init }
 CMFireAutomataModel >> init58 [
 	self
-		createGridColumns: 80
-		lines: 80
+		createGridLines: 80
+		columns: 80
 		neighbourhood: 4
 		closed: false.
 	self initCells: #init58
@@ -483,8 +483,8 @@ CMFireAutomataModel >> init58WithFire [
 CMFireAutomataModel >> init58WithFireWithFiremen [
 	| aCell |
 	self
-		createGridColumns: 80
-		lines: 80
+		createGridLines: 80
+		columns: 80
 		neighbourhood: 4
 		closed: false.
 	self initCells: #init58.
@@ -516,8 +516,8 @@ CMFireAutomataModel >> initAgents [
 CMFireAutomataModel >> initSmallWithFireWithFiremen [
 	| aCell |
 	self
-		createGridColumns: 40
-		lines: 40
+		createGridLines: 40
+		columns: 40
 		neighbourhood: 4
 		closed: false.
 	self initCells: #init58.
@@ -533,8 +533,8 @@ CMFireAutomataModel >> initSmallWithFireWithFiremen [
 CMFireAutomataModel >> initWithFiremen [
 	| aCell |
 	self
-		createGridColumns: 80
-		lines: 80
+		createGridLines: 80
+		columns: 80
 		neighbourhood: 4
 		closed: false.
 	self initCells: #initWith: withArguments: {60}.

--- a/repository/Cormas-Model-FireAutomata/CMFireAutomataModelTest.class.st
+++ b/repository/Cormas-Model-FireAutomata/CMFireAutomataModelTest.class.st
@@ -14,8 +14,8 @@ CMFireAutomataModelTest >> testDominanceOfAModelIsLessThanOne [
 	aModel class defaultInit: #init58WithFire.
 	aModel initializeSpaceModel.
 	aModel
-		createGridColumns: 100
-		lines: 100
+		createGridLines: 100
+		columns: 100
 		neighbourhood: 4
 		closed: true.
 	aModel initSimulation.
@@ -39,8 +39,8 @@ CMFireAutomataModelTest >> testNumberOfDifferentStateInAFireAutomataIsThree [
 	aModel class defaultInit: #init58WithFire.
 	aModel initializeSpaceModel.
 	aModel
-		createGridColumns: 10
-		lines: 10
+		createGridLines: 10
+		columns: 10
 		neighbourhood: 4
 		closed: true.
 	aModel initSimulation.
@@ -56,8 +56,8 @@ CMFireAutomataModelTest >> testSizeOfCellsColumnOfFireAutomataModelIsTen [
 		new.
 	aModel initializeSpaceModel.
 	aModel
-		createGridColumns: 10
-		lines: 10
+		createGridLines: 10
+		columns: 10
 		neighbourhood: 4
 		closed: true.
 	aModel activeInit: #init58WithFire.
@@ -74,8 +74,8 @@ CMFireAutomataModelTest >> testWhenAfterRunningTheModel20TimesTheProbesResultHav
 	aModel := modelClass new.
 	aModel initializeSpaceModel.
 	aModel
-		createGridColumns: 100
-		lines: 100
+		createGridLines: 100
+		columns: 100
 		neighbourhood: 4
 		closed: true.
 	nbSteps := 20.
@@ -97,8 +97,8 @@ CMFireAutomataModelTest >> testWhenYouPickACellOfAModelThisIsASpatialEntity [
 	aModel := modelClass new.
 	aModel initializeSpaceModel.
 		aModel
-		createGridColumns: 100
-		lines: 100
+		createGridLines: 100
+		columns: 100
 		neighbourhood: 4
 		closed: true.
 	aModel initSimulation.

--- a/repository/Cormas-Model-PlotsRental/CMPlotsRentalModel.class.st
+++ b/repository/Cormas-Model-PlotsRental/CMPlotsRentalModel.class.st
@@ -337,8 +337,8 @@ CMPlotsRentalModel >> initCells [
 	"10x10 cells"
 
 	self
-		createGridColumns: 10
-		lines: 10
+		createGridLines: 10
+		columns: 10
 		neighbourhood: 8
 		closed: true
 ]

--- a/repository/Cormas-Tests/CormasModelTest.class.st
+++ b/repository/Cormas-Tests/CormasModelTest.class.st
@@ -13,8 +13,8 @@ CormasModelTest >> testCentralCell [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 3
-			lines: 3
+		createGridLines: 3
+			columns: 3
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -32,8 +32,8 @@ CormasModelTest >> testCreateGridXYNeighborHoodClosed [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -51,8 +51,8 @@ CormasModelTest >> testDominance [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 100
-			lines: 100
+		createGridLines: 100
+			columns: 100
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -69,8 +69,8 @@ CormasModelTest >> testDominance1 [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 100
-			lines: 100
+		createGridLines: 100
+			columns: 100
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -86,8 +86,8 @@ CormasModelTest >> testLowerLeftCell [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 3
-			lines: 3
+		createGridLines: 3
+			columns: 3
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -105,8 +105,8 @@ CormasModelTest >> testLowerRightCell [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 3
-			lines: 3
+		createGridLines: 3
+			columns: 3
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -124,8 +124,8 @@ CormasModelTest >> testNbDistinctValuesOf [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -145,8 +145,8 @@ CormasModelTest >> testPickCell [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -165,8 +165,8 @@ CormasModelTest >> testPickCellConstrainedBy [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 9
-			lines: 9
+		createGridLines: 9
+			columns: 9
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -189,8 +189,8 @@ CormasModelTest >> testPickCellWithoutAny [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation;
@@ -210,8 +210,8 @@ CormasModelTest >> testPickCellsN [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -228,8 +228,8 @@ CormasModelTest >> testPickEntity [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -245,8 +245,8 @@ CormasModelTest >> testPickEntityConstrainedBy [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -279,8 +279,8 @@ CormasModelTest >> testPickNEntities [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -298,8 +298,8 @@ CormasModelTest >> testPickNEntitiesConstrainedBy [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -321,8 +321,8 @@ CormasModelTest >> testPickUnoccupiedCell [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation;
@@ -346,8 +346,8 @@ CormasModelTest >> testSelectCellsInRectangle [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -368,8 +368,8 @@ CormasModelTest >> testSelectCellsInRectangleOriginCellCornerCell [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 5
-			lines: 9
+		createGridLines: 9
+			columns: 5
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -392,8 +392,8 @@ CormasModelTest >> testSelectCellsOfColumn [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -414,8 +414,8 @@ CormasModelTest >> testSelectCellsOfLine [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -459,8 +459,8 @@ CormasModelTest >> testTheAgents [
 		activeInit: #initAlive;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 10
-			lines: 20
+		createGridLines: 20
+			columns: 10
 			neighbourhood: 4
 			closed: true;
 		initSimulation;
@@ -481,8 +481,8 @@ CormasModelTest >> testUpperLeftCell [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 3
-			lines: 3
+		createGridLines: 3
+			columns: 3
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
@@ -500,8 +500,8 @@ CormasModelTest >> testUpperRightCell [
 		activeInit: #initRandom;
 		initSimulation;
 		initializeSpaceModel;
-		createGridColumns: 3
-			lines: 3
+		createGridLines: 3
+			columns: 3
 			neighbourhood: 4
 			closed: true;
 		initSimulation.


### PR DESCRIPTION
columns:lines: -> lines:columns: