### PR TITLE
automatic-transform-Cell-x-and-y-to-numCol-and-numLine

### DIFF
--- a/repository/Cormas-Core/CMSpatialEntityElement.class.st
+++ b/repository/Cormas-Core/CMSpatialEntityElement.class.st
@@ -1030,7 +1030,9 @@ CMSpatialEntityElement >> x [
 
 	"Purpose: returns the X coordinate of the cell in a regular spatial grid"
 
-	self deprecated: 'Please use "numCol" instead.'.
+	self
+		deprecated: 'Please use "numCol" instead.'
+		transformWith: '`@receiver x' -> '`@receiver numCol'.
 	^ self numCol
 ]
 
@@ -1040,6 +1042,8 @@ CMSpatialEntityElement >> y [
 
 	"Purpose: returns the Y coordinate of the cell in a regular spatial grid"
 
-	self deprecated: 'Please use "numLine" instead.'.
+	self
+		deprecated: 'Please use "numLine" instead.'
+		transformWith: '`@receiver y' -> '`@receiver numLine'.
 	^ self numLine
 ]

--- a/repository/Cormas-Tests/CormasModelTest.class.st
+++ b/repository/Cormas-Tests/CormasModelTest.class.st
@@ -424,7 +424,7 @@ CormasModelTest >> testSelectCellsOfLine [
 		| cells |
 		cells := model selectCellsOfLine: line.
 		self assert: cells size equals: 10.
-		cells do: [ :cell | self assert: cell y equals: line ] ]
+		cells do: [ :cell | self assert: cell numLine equals: line ] ]
 ]
 
 { #category : #tests }


### PR DESCRIPTION
models that use cell's x and y are automatically transformed to use numCol and numLine.