### PR TITLE
124-selectCellsInRectangle-has-strange-coordinates

### DIFF
--- a/repository/Cormas-Core/CMSpaceModel.class.st
+++ b/repository/Cormas-Core/CMSpaceModel.class.st
@@ -424,38 +424,39 @@ lineNumber2   <Integer> colNumber = Positive Integer"
 
 { #category : #'ESE (regular) - special locations' }
 CMSpaceModel >> cellsBetweenLine1: lineNumber1 line2: lineNumber2 andColumn1: colNumber1 column2: colNumber2 [
-	"Return the cells between the lines lineNumber1 and lineNumber2, and between the columns colNumber1 and colNumber2 of the spatial grid. The Cells are sorted by id.
-lineNumber1   <Integer> lineNumber = Positive Integer
-lineNumber2   <Integer> colNumber = Positive Integer
-colNumber1   <Integer> lineNumber = Positive Integer
-colNumber2   <Integer> colNumber = Positive Integer
-Ex:  cellsBetweenLine1: 1 line2: 6 andColumn1: 2 column2: 3  ->  a collection of cells between columns 2 and 3, and between lines 1 and 6, and ordered from line 1 to line 6"
-	
-	| l1 l2 c1 c2 |
+	"Purpose: Return the cells between the lines lineNumber1 and lineNumber2, and between the columns colNumber1 and colNumber2 of the spatial grid. The Cells are sorted by id.
+Arguments: lineNumber1   <Integer> lineNumber = Positive Integer
+Arguments: lineNumber2   <Integer> colNumber = Positive Integer
+Arguments: colNumber1   <Integer> lineNumber = Positive Integer
+Arguments: colNumber2   <Integer> colNumber = Positive Integer
+Example:  cellsBetweenLine1: 1 line2: 6 andColumn1: 2 column2: 3  ->  a collection of cells between columns 2 and 3, and between lines 1 and 6, and ordered from line 1 to line 6"
+
+	| l1 l2 c1 c2 cellsCol |
 	l1 := lineNumber1 min: lineNumber2.
 	l2 := lineNumber1 max: lineNumber2.
 	c1 := colNumber1 min: colNumber2.
 	c2 := colNumber1 max: colNumber2.
-	^self
-		cellsIntoRectangle:
-			(Rectangle
-				origin: l1 @ c1
-				corner: l2 @ c2)
+	cellsCol := self cellsBetweenColumn1: c1 andColumn2: c2.
+	^ (self cellsBetweenLine1: l1 andLine2: l2)
+		select: [ :c | cellsCol includes: c ]
 ]
 
 { #category : #'ESE (regular) - special locations' }
 CMSpaceModel >> cellsIntoRectangle: aRectangle [
-	"Return the cells between the lineNumber and the colNumber of the spatial grid. The Cells are sorted by id.
-aRectangle   <Rectangle> where origin < corner.
-Ex:  cellsIntoRectangle: (Rectangle origin: 1@2 corner: 6@3)  ->  a collection of cells between columns 2 and 3, and between lines 1 and 6, and ordered from line 1 to line 6"
-	
+	"This method is deprecated. Please use cellsBetwenLine1:line2:andColumn1:column2: instead.
+Purpose: Return the cells between the lineNumber and the colNumber of the spatial grid. The Cells are sorted by id.
+Argument: aRectangle   <Rectangle> where origin < corner.
+Example:  cellsIntoRectangle: (Rectangle origin: 1@2 corner: 6@3)  ->  a collection of cells between columns 2 and 3, and between lines 1 and 6, and ordered from line 1 to line 6"
+
 	| cellsCol |
+	self
+		deprecated: 'Please use cellsBetwenLine1:line2:andColumn1:column2: instead.'.
 	cellsCol := self
 		cellsBetweenColumn1: aRectangle origin y
 		andColumn2: aRectangle corner y.
-	^(self
+	^ (self
 		cellsBetweenLine1: aRectangle origin x
-		andLine2: aRectangle corner x) select: [:c | cellsCol includes: c]
+		andLine2: aRectangle corner x) select: [ :c | cellsCol includes: c ]
 ]
 
 { #category : #'ESE (regular) - special locations' }

--- a/repository/Cormas-Core/CormasModel.class.st
+++ b/repository/Cormas-Core/CormasModel.class.st
@@ -4650,12 +4650,36 @@ file <String> ex: 'titi.txt'  it will be save into data/"
 ]
 
 { #category : #'+ accessing - entities' }
+CormasModel >> selectCellsBetweenLine1: lineNumber1 line2: lineNumber2 andColumn1: colNumber1 column2: colNumber2 [
+	"Purpose: Return the cells between the lines lineNumber1 and lineNumber2, and between the columns colNumber1 and colNumber2 of the spatial grid. The Cells are sorted by id.
+Arguments: lineNumber1   <Integer> lineNumber = Positive Integer
+Arguments: lineNumber2   <Integer> colNumber = Positive Integer
+Arguments: colNumber1   <Integer> lineNumber = Positive Integer
+Arguments: colNumber2   <Integer> colNumber = Positive Integer
+Example:  cellsBetweenLine1: 1 line2: 6 andColumn1: 2 column2: 3  ->  a collection of cells between columns 2 and 3, and between lines 1 and 6, and ordered from line 1 to line 6"
+
+	^ self spaceModel
+		cellsBetweenLine1: lineNumber1
+		line2: lineNumber2
+		andColumn1: colNumber1
+		column2: colNumber2
+]
+
+{ #category : #'+ accessing - entities' }
 CormasModel >> selectCellsInRectangle: aRectangle [
+	"This method is deprecated. Please use selectCellsBetweenLine1:line2:andColumn1:column2: ."
+
 	"Purpose: return a collection of the cells located in a rectangle defined by an origin cell (top left) and a corner cell (down right). The collection of cells is sorted by id.
 	Argument: aRectangle   <Rectangle> where origin < corner.
 	Example: self  selectCellsInRectangle: (Rectangle origin: 1@2 corner: 6@3)  ->  a collection of cells between columns 2 and 3, and between lines 1 and 6, and ordered from line 	1 to line 6"
 
-	^ self spaceModel cellsIntoRectangle: aRectangle
+	self
+		deprecated: 'Please use selectCellsBetweenLine1:line2:andColumn1:column2: instead'.
+	^ self
+		selectCellsBetweenLine1: aRectangle left
+		line2: aRectangle right
+		andColumn1: aRectangle top
+		column2: aRectangle bottom
 ]
 
 { #category : #'+ accessing - entities' }

--- a/repository/Cormas-Tests/CormasModelTest.class.st
+++ b/repository/Cormas-Tests/CormasModelTest.class.st
@@ -338,7 +338,7 @@ CormasModelTest >> testProbes [
 ]
 
 { #category : #'tests-accessing-entities' }
-CormasModelTest >> testSelectCellsInRectangle [
+CormasModelTest >> testSelectCellsBetweenLine1Line2AndColumn1Column2 [
 	| model cells |
 	model := (CormasModelForTest
 		initialize;
@@ -351,12 +351,16 @@ CormasModelTest >> testSelectCellsInRectangle [
 			neighbourhood: 4
 			closed: true;
 		initSimulation.
-	cells := model selectCellsInRectangle: (5 @ 5 corner: 7 @ 7).
+	cells := model
+		selectCellsBetweenLine1: 13
+		line2: 15
+		andColumn1: 6
+		column2: 8.
 	self assert: cells size equals: 9.
 	cells
 		do: [ :cell | 
-			self assert: (cell numCol between: 5 and: 7).
-			self assert: (cell numLine between: 5 and: 7) ]
+			self assert: (cell numCol between: 6 and: 8).
+			self assert: (cell numLine between: 13 and: 15) ]
 ]
 
 { #category : #'tests-accessing-entities' }


### PR DESCRIPTION
deprecate CormasModel>>selectSellsInRectangle and CMSpaceModel>>cellsIntoRectangle, and add CormasModel>>selectCellsBetweenLine1:line2:andColumn1:column2: as the alternative. Test case is adjusted.