### PR TITLE
Remove addNewClassType: methods in Cormas

### DIFF
--- a/repository/Cormas-Core/Cormas.class.st
+++ b/repository/Cormas-Core/Cormas.class.st
@@ -4241,51 +4241,6 @@ Cormas >> addClassFrom: aSuperClass [
 			self modifyPassiveEntityClass]
 ]
 
-{ #category : #'model entities' }
-Cormas >> addNewClassType: aType inheritingFrom: aSuperclass defaultName: aString [
-	
-	^self addNewClassType: aType inheritingFrom: aSuperclass defaultName:
-			aString initProtocol: false stepProtocol: false
-]
-
-{ #category : #'model entities' }
-Cormas >> addNewClassType: aType inheritingFrom: aSuperclass defaultName: aString initProtocol: createInit stepProtocol: createStep [
-	
-	^self
-		addNewClassType: aType
-		inheritingFrom: aSuperclass
-		name: (self askUserTheClassNameWithDefaultValue: aString)
-		initProtocol: createInit
-		stepProtocol: createStep
-]
-
-{ #category : #'model entities' }
-Cormas >> addNewClassType: aType inheritingFrom: aSuperclass name: aName initProtocol: createInit stepProtocol: createStep [
-	
-	| newClass selectionInList selector newList |
-	self flag:#shouldBeRevised.
-	self cormasModelClass isNil ifTrue: [^self alert_NewModel].
-	(aName isNil or: [aName isEmpty]) ifTrue: [^nil].
-	newClass := self createClassNamed: aName from: aSuperclass.
-	selector := ((Cormas lowerCaseString: aType) , 'Classes') asSymbol.
-	(self cormasModelClass perform: selector) add: newClass.
-	(newClass inheritsFrom: CMSpatialEntityElement)
-		ifTrue: [self cormasModelClass cellClass: newClass].
-	selectionInList := self perform: ('list' , aType , 'Entities') asSymbol.	"selectionInList list add: aName asSymbol."
-	newList := self getSortedListEntityClassType: aType.
-	selectionInList list: newList.
-	selectionInList
-		selection:
-			(newList
-				detect: [:s | (Cormas dropBlanksFromString: s) = aName]
-				ifNone: [self halt]).
-	self createModelAccessors: newClass.
-	self createProtocol: #control forClass: newClass.
-	createInit ifTrue: [self createInit: newClass].
-	createStep ifTrue: [self createStep: newClass].	"self modifyEntityClassType: aType."
-	^newClass
-]
-
 { #category : #'main menu' }
 Cormas >> addOnHowTo [
 	


### PR DESCRIPTION
Remove addNewClassType: methods in Cormas. Corresponding methods are implemented in GStCormas