### PR TITLE
Changes in CMAbstractModel

### DIFF
--- a/repository/Cormas-Core/CMAbstractModel.class.st
+++ b/repository/Cormas-Core/CMAbstractModel.class.st
@@ -226,39 +226,26 @@ CMAbstractModel class >> allActivitySelectors [
 ]
 
 { #category : #'managing classes' }
-CMAbstractModel class >> allClasses [
-	"return all the classes of the model (except the classes that inheriting from Msg and other classes like Interface etc"
-
-	| collection |
-	collection := self allClassesInPackage.
-	collection removeAllSuchThat: [:cl | (cl inheritsFrom: CMEntity) not].
-	^ collection
-]
-
-{ #category : #'managing classes' }
 CMAbstractModel class >> allClassesInPackage [
-"Returns all classes of the package ie. we the correct tag"
-"^ self package classes   doesn't work because doesn't take tags into account"
+	"Returns all classes of the package in the same tag than the model (include the model)"
 
-^(self package classTags detect: [ :each | each includesClass: self ]) classes.
-	
+	^ (self package classTags
+		detect: [ :class | class includesClass: self ]) classes
 ]
 
 { #category : #'managing classes' }
 CMAbstractModel class >> allClassesNames [
-	"return all the Entity class names of the model (except the my self, Msg and other classes like Interface etc"
-	
-	^self allEntityClasses collect: [:c | c name asString]
+	"return all the Entity class names of the model (except the my self, Msg and other classes like Interface etc)"
+
+	^ self allEntityClasses collect: [ :c | c name asString ]
 ]
 
 { #category : #'managing classes' }
 CMAbstractModel class >> allEntityClasses [
 	"return all the classes of the model (except the classes that inheriting from Msg and other classes like Interface etc"
 
-	| collection |
-	collection := self allClassesInPackage.
-	collection removeAllSuchThat: [:cl | (cl inheritsFrom: CMEntity) not].
-	^ collection
+	^ self allClassesInPackage
+		removeAllSuchThat: [ :class | (class inheritsFrom: CMEntity) not ]
 ]
 
 { #category : #'- activityEditor' }
@@ -639,28 +626,30 @@ CMAbstractModel class >> initialize [
 
 { #category : #'instance creation' }
 CMAbstractModel class >> initializeCellClass [
-"Store the Cell class of the model into #cellClass"
-	self cellClass: (self allEntityClasses
-		detect: [ :cl | cl inheritsFrom: CMSpatialEntityElement ]
-		ifNone: [ nil ]).
+	"Store the Cell class of the model into cellClass"
 
+	self
+		cellClass:
+			(self allEntityClasses
+				detect: [ :each | each inheritsFrom: CMSpatialEntityElement ]
+				ifNone: [ nil ])
 ]
 
 { #category : #'instance creation' }
 CMAbstractModel class >> initializeModelClasses [
-	"Distributes and stores the classes of the model in the 3 main archetypes (spatialClasses, socialClasses and passiveClasses)"
+	"Decompose classes of the model in spatial, social and passive classes"
 
-	| collec subset |
-	collec := self allClassesInPackage.
-	subset := collec select: [ :e | e inheritsFrom: CMSpatialEntity ].
-	self spatialClasses: subset.
-	
-	subset := collec select: [ :e | e inheritsFrom: CMAgent ].
-	self socialClasses: subset.
-	
-	subset := collec
-		select: [ :e | (e inheritsFrom: CMPassiveObject) or: [ e inheritsFrom: CMMsg ] ].
-	self passiveClasses: subset
+	| classes |
+	classes := self allClassesInPackage.
+	self
+		spatialClasses: (classes select: [ :each | each inheritsFrom: CMSpatialEntity ]).
+	self
+		socialClasses: (classes select: [ :each | each inheritsFrom: CMAgent ]).
+	self
+		passiveClasses:
+			(classes
+				select:
+					[ :each | (each inheritsFrom: CMPassiveObject) or: [ each inheritsFrom: CMMsg ]])
 ]
 
 { #category : #'- activityEditor' }

--- a/repository/Cormas-Core/Cormas.class.st
+++ b/repository/Cormas-Core/Cormas.class.st
@@ -1409,15 +1409,15 @@ Cormas class >> originPointOfWindowExtent: bounds toPlaceOnSideOf: mainWindow an
 
 { #category : #accessing }
 Cormas class >> passiveEntitiesClassNames [
-	
 	| collec |
 	collec := OrderedCollection new.
 	collec
 		add: 'Msg';
 		add: 'PassiveObject'.
-	self cmEnvironment allClasses "should be allEntityClasses ??" 
-		do: [ : aClass | (aClass inheritsFrom: CMPassiveObject)
-			ifTrue: [collec add: aClass name asString ] ].
+	self cmEnvironment allEntityClasses
+		do: [ :aClass | 
+			(aClass inheritsFrom: CMPassiveObject)
+				ifTrue: [ collec add: aClass name asString ] ].	"should be allEntityClasses ??"
 	^ collec
 ]
 
@@ -2220,11 +2220,10 @@ ex: Cormas selectSimpleRandomlyFrom: (Set withAll: #(1 2 3 4 5))"
 
 { #category : #'util_export' }
 Cormas class >> selectedThingsWithOrder: aBlock onSelection: aNameSpace [
-	
 	| things |
 	things := OrderedCollection new.
 	things add: aNameSpace.
-	things addAll: aNameSpace allClasses.
+	things addAll: aNameSpace allEntityClasses.
 	things addAll: aNameSpace allNameSpaces.
 	things := SystemUtils sortForLoading: things.
 	aBlock value: things
@@ -2488,13 +2487,13 @@ example: Environment updateTemperature: time
 
 { #category : #accessing }
 Cormas class >> socialEntitiesClassNames [
-	
 	| collec |
 	collec := OrderedCollection new.
 	collec add: 'Agent'.
-	self cmEnvironment allClasses "should be allEntityClasses ??" 
-		do: [ : aClass | (aClass inheritsFrom: CMAgent) 
-				ifTrue: [ collec add: aClass name asString ] ].
+	self cmEnvironment allEntityClasses 
+		do: [ :aClass | 
+			(aClass inheritsFrom: CMAgent)
+				ifTrue: [ collec add: aClass name asString ] ].	"should be allEntityClasses ??"
 	^ collec
 ]
 
@@ -2604,14 +2603,13 @@ Example: Cormas sortIncreasingly: #( 2 1 3)	 => aSortedCollection (1 2 3)"
 
 { #category : #accessing }
 Cormas class >> spatialEntitiesClassNames [
-	
 	| collec |
 	collec := OrderedCollection new.
-	self cmEnvironment allClasses "should be allEntityClasses ??" 
-		do: [ : aClass | 
+	self cmEnvironment allEntityClasses 
+		do: [ :aClass | 
 			(aClass inheritsFrom: CMSpatialEntity)
-				ifTrue: [ collec add: aClass name asString ] ].
-	^collec
+				ifTrue: [ collec add: aClass name asString ] ].	"should be allEntityClasses ??"
+	^ collec
 ]
 
 { #category : #'+ utilities - files' }

--- a/repository/Cormas-Model-Conway/CMConwayModelTest.class.st
+++ b/repository/Cormas-Model-Conway/CMConwayModelTest.class.st
@@ -46,6 +46,11 @@ CMConwayModelTest >> testConwayModelHasOnlyOneSpatialEntityClass [
 ]
 
 { #category : #tests }
+CMConwayModelTest >> testThereIsOneEntityClassInConwayModel [
+	self assert: CMConwayModel allEntityClasses size equals: 1
+]
+
+{ #category : #tests }
 CMConwayModelTest >> testThereIsTwoClassesInConwayPackage [
 	self assert: CMConwayModel allClassesInPackage size equals: 2
 ]


### PR DESCRIPTION
 Remove allClasses because duplicate of allEntityClasses
Simplify management of classes in CMAbstractModel
Add one test for allEntityClasses

