### PR TITLE
Update the main window UI when metadata (version) is changed in Metho…

### DIFF
--- a/repository/Cormas-Core/CMProjectAnnouncement.class.st
+++ b/repository/Cormas-Core/CMProjectAnnouncement.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #CMProjectAnnouncement,
+	#superclass : #Announcement,
+	#category : #'Cormas-Core-Announcement'
+}

--- a/repository/Cormas-Core/CMProjectNewAnnouncement.class.st
+++ b/repository/Cormas-Core/CMProjectNewAnnouncement.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #CMProjectNewAnnouncement,
+	#superclass : #CMProjectAnnouncement,
+	#category : #'Cormas-Core-Announcement'
+}

--- a/repository/Cormas-Core/CMProjectOpenAnnouncement.class.st
+++ b/repository/Cormas-Core/CMProjectOpenAnnouncement.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #CMProjectOpenAnnouncement,
+	#superclass : #CMProjectAnnouncement,
+	#category : #'Cormas-Core-Announcement'
+}

--- a/repository/Cormas-Core/CMProjectRenameAnnouncement.class.st
+++ b/repository/Cormas-Core/CMProjectRenameAnnouncement.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #CMProjectRenameAnnouncement,
+	#superclass : #CMProjectAnnouncement,
+	#category : #'Cormas-Core-Announcement'
+}

--- a/repository/Cormas-Core/CMProjectUpdateAnnouncement.class.st
+++ b/repository/Cormas-Core/CMProjectUpdateAnnouncement.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #CMProjectUpdateAnnouncement,
+	#superclass : #CMProjectAnnouncement,
+	#category : #'Cormas-Core-Announcement'
+}

--- a/repository/Cormas-UI/CMProjectManager.class.st
+++ b/repository/Cormas-UI/CMProjectManager.class.st
@@ -65,6 +65,7 @@ CMProjectManager >> cormasModelAuthors: aString [
 
 { #category : #accessing }
 CMProjectManager >> cormasModelClass [
+	" Answer a <Class> representing the model class of the receiver's current project "
 
 	^ self currentProject cormasModelClass
 ]
@@ -74,13 +75,6 @@ CMProjectManager >> cormasModelCreationDate: aString [
 
 	self currentProject cormasModelCreationDate: aString
 
-]
-
-{ #category : #accessing }
-CMProjectManager >> cormasModelEmails: aString [
-	" Set aString with emails (one by line) to the receiver's model "
-
-	self currentProject cormasModelEmails: aString
 ]
 
 { #category : #accessing }
@@ -107,14 +101,14 @@ CMProjectManager >> cormasModelVersion: aString [
 
 ]
 
-{ #category : #callbacks }
+{ #category : #accessing }
 CMProjectManager >> cormasModels [
 	" Answer a <Collection> of <String> with receiver's available models "
 	
 	^ self application modelNames
 ]
 
-{ #category : #callbacks }
+{ #category : #accessing }
 CMProjectManager >> cormasOpenLocations [
 	" Answer a Collection of valid locations for opening a Cormas model "
 	
@@ -122,7 +116,7 @@ CMProjectManager >> cormasOpenLocations [
 
 ]
 
-{ #category : #callbacks }
+{ #category : #accessing }
 CMProjectManager >> cormasOpenLocationsMap [
 	" Answer a Collection of valid locations for opening a Cormas model "
 
@@ -142,35 +136,70 @@ CMProjectManager >> createClassModelNamed: modelName [
 ]
 
 { #category : #callbacks }
-CMProjectManager >> createNewProject [
-	" Private - See superimplementor's comment "
+CMProjectManager >> createProject: projectName in: aCMApplicationProject [
+
+	| newProject |
 	
-	| answer |
+	newProject := aCMApplicationProject createProjectNamed: projectName.
+	aCMApplicationProject currentProject: newProject.
+	self updateNewProject: projectName.
+	self fsm handleEvent: #actionNew.
 
-	(answer := self requestMessage: self translator tNewProjectName) isEmptyOrNil 
-		ifFalse: [ 
-			self createAppProject: answer.
-			self doPostNewActions.
-			(CMSpecModelComments for: self) openWithSpec ]
-		ifTrue: [ self informMessage: self translator tNewProjectEmptyName ].
+]
 
+{ #category : #testing }
+CMProjectManager >> currentProjectAuthors [
+	" Answer a <String> containing receiver's model authors "
+
+	^ self currentProject cormasModelClass cmAuthors
+
+]
+
+{ #category : #accessing }
+CMProjectManager >> currentProjectHasAuthor [
+	" Answer <true> if the receiver's model has comments "
+
+	^ self currentProject cormasModelClass respondsTo: #cmAuthors
+]
+
+{ #category : #testing }
+CMProjectManager >> currentProjectHasComments [
+	" Answer <true> if the receiver's model has comments "
+
+	^ self currentProject cormasModelClass respondsTo: #comments
+]
+
+{ #category : #testing }
+CMProjectManager >> currentProjectHasCreationDate [
+	" Answer <true> if receiver's contains a version name "
+
+	^  self currentProject cormasModelClass respondsTo: #creationDate
+]
+
+{ #category : #testing }
+CMProjectManager >> currentProjectHasVersion [
+	" Answer <true> if receiver's contains a version name "
+
+	^  self currentProject cormasModelClass respondsTo: #version
+]
+
+{ #category : #testing }
+CMProjectManager >> currentProjectVersion [
+	" Answer a <String> containing receiver's current version name. If no version is found, answer a descriptive string reflecting the situation (i.e. 'no version') "
+
+	^ [ self currentProject cormasModelClass version ]
+	on: MessageNotUnderstood 
+	do: [ : ex | self translator tNoVersion ]
 
 ]
 
 { #category : #callbacks }
 CMProjectManager >> doPostNewActions [
-	" Private - See superimplentor's comment "
+	" Basic post new actions. Redefine in subclasses if necessary "
 
-	self updateNewProject: self cormasModelName.
 	super doPostNewActions.
-]
+	(CMSpecModelComments for: self) openWithSpec.
 
-{ #category : #callbacks }
-CMProjectManager >> doPostOpenActions [
-	" Private - See superimplentor's comment "
-
-	self updateNewProject: self cormasModelName.
-	super doPostOpenActions.
 ]
 
 { #category : #callbacks }
@@ -319,7 +348,7 @@ CMProjectManager >> requestModelOpenDialogFromLocalDisk [
 
 { #category : #callbacks }
 CMProjectManager >> requestModelOpenDialogFromLocalImage [
-	" Open a Cormas model. Answer project creation status, <true> if project was opened successfully "
+	" Open a Cormas model. Answer a <String> with the project name it it was opened successfully, nil otherwise "
 
 	| widget |
 	widget := SpcListModel new.
@@ -327,7 +356,9 @@ CMProjectManager >> requestModelOpenDialogFromLocalImage [
 		title: self translator tWhichModel;
 		items: CMAbstractModel subclasses.
 	widget openDialogWithSpec modalRelativeTo: self currentWorld.
-	^ widget selectedItem name
+	^ widget selectedItem 
+		ifNotNil: [ : selection | selection name ]
+		ifNil: [ widget selectedItem ]
 ]
 
 { #category : #callbacks }
@@ -374,7 +405,6 @@ CMProjectManager >> updateNewProject: modelName [
 	self currentProject cormasModel: self cormasModelClass new.
 	self cormasModelClass initialize.
 	self cormasModel projectManager: self.
-	super updateNewProject: modelName.
 	self cormasModel timeStep: 0.
 ]
 

--- a/repository/Cormas-UI/CMProjectModel.class.st
+++ b/repository/Cormas-UI/CMProjectModel.class.st
@@ -65,10 +65,10 @@ CMProjectModel >> cormasModel: aCormasModel [
 { #category : #accessing }
 CMProjectModel >> cormasModelAuthors: aString [ 
 	" See comment in CMProjectManager>>cormasModelAuthors: "
-	
-	self codeGenerator 
+
+	self codeGenerator
 		generateMethod: aString 
-		selector: #authors 
+		selector: #cmAuthors 
 		inClass: self cormasModelClass class.
 
 ]
@@ -96,17 +96,6 @@ CMProjectModel >> cormasModelCreationDate: aString [
 		selector: #creationDate 
 		inClass: self cormasModelClass class.
 
-
-]
-
-{ #category : #accessing }
-CMProjectModel >> cormasModelEmails: aString [ 
-	" See comment in CMProjectManager>>cormasModelEmails: "
-
-	self codeGenerator 
-		generateMethod: aString 
-		selector: #emails 
-		inClass: self cormasModelClass class.
 
 ]
 

--- a/repository/Cormas-UI/CMSpecModelComments.class.st
+++ b/repository/Cormas-UI/CMSpecModelComments.class.st
@@ -26,7 +26,7 @@ Class {
 		'toolbar',
 		'creationDate'
 	],
-	#category : 'Cormas-UI-Core'
+	#category : #'Cormas-UI-Core'
 }
 
 { #category : #specs }
@@ -50,14 +50,13 @@ CMSpecModelComments class >> defaultSpec [
 { #category : #callbacks }
 CMSpecModelComments >> addModelComments [
 	" Private - User has clicked Ok to add model comments "
-	
+
 	self projectManager 
 		cormasModelCreationDate: self creationDate textValuePending;
 		cormasModelVersion: self versionName textValuePending;
-		cormasModelAuthors: self authorList authors;
-		cormasModelEmails: self authorList emails;
+		cormasModelAuthors: self authorList textValuePending;
 		cormasModelText: self modelText textValuePending.
-		
+	self projectAnnouncer announce: CMProjectUpdateAnnouncement new
 
 ]
 
@@ -83,6 +82,42 @@ CMSpecModelComments >> creationDate: anObject [
 	creationDate := anObject
 ]
 
+{ #category : #initialization }
+CMSpecModelComments >> currentProjectAuthors [
+	" See comment in ProjectManager #currentProjectAuthors method "
+	
+	^ self projectManager currentProjectAuthors
+]
+
+{ #category : #initialization }
+CMSpecModelComments >> currentProjectClass [
+	" See comment in ProjectManager #currentProjectVersion method "
+	
+	^ self currentProject cormasModelClass
+]
+
+{ #category : #initialization }
+CMSpecModelComments >> currentProjectVersion [
+	" See comment in ProjectManager #currentProjectVersion method "
+	
+	^ self projectManager currentProjectVersion
+]
+
+{ #category : #defaults }
+CMSpecModelComments >> defaultAuthorList [
+	" Answer a <String> with some default text for authors list "
+	
+	^ 'Author1;email1@author1.com
+Author2;email2@author2.com
+'
+]
+
+{ #category : #defaults }
+CMSpecModelComments >> defaultVersionName [
+
+	^ '1.0'
+]
+
 { #category : #api }
 CMSpecModelComments >> initialExtent [
 	"Answer the initial extent for the receiver."
@@ -91,17 +126,51 @@ CMSpecModelComments >> initialExtent [
 ]
 
 { #category : #initialization }
-CMSpecModelComments >> initializePresenter [
-	" Private - See superimplementor's comment "
-	
-	self versionName
-		label: self translator tVersionName;
-		ghostText: '1.0'.
+CMSpecModelComments >> initializeAuthors [
+
+	self authorList
+		label: self translator tVersionName.
+	self authorList text: (self projectManager currentProjectHasAuthor
+		ifTrue: [  self currentProjectAuthors ]
+		ifFalse: [ self defaultAuthorList ])
+]
+
+{ #category : #initialization }
+CMSpecModelComments >> initializeCreationDateField [
+
 	self creationDate 
 		label: self translator tCreationDate;
 		ghostText: Date today asString.
+	self projectManager currentProjectHasCreationDate
+		ifTrue: [ self creationDate textValue: self projectManager currentProjectCreationDate ].
+	self creationDate disable
+]
+
+{ #category : #initialization }
+CMSpecModelComments >> initializeModelComments [
+
 	self modelText
 		label: self translator tModelComments.
+	self projectManager currentProjectHasComments
+		ifTrue: [ self modelText text: self cormasModelClass comments ].
+
+]
+
+{ #category : #initialization }
+CMSpecModelComments >> initializePresenter [
+	" Private - See superimplementor's comment "
+	
+	self 
+		initializeVersionField;
+		initializeCreationDateField;
+		initializeModelComments;
+		initializeAuthors;
+		initializeToolbar.
+]
+
+{ #category : #initialization }
+CMSpecModelComments >> initializeToolbar [
+
 	self toolbar 
 "		firstButtonLabel: 'Cancel';
 		firstButtonAction: [ self delete ];"
@@ -112,17 +181,28 @@ CMSpecModelComments >> initializePresenter [
 ]
 
 { #category : #initialization }
+CMSpecModelComments >> initializeVersionField [
+
+	self versionName
+		label: self translator tVersionName;
+		ghostText: self defaultVersionName.
+	self projectManager currentProjectHasVersion
+		ifTrue: [ self versionName textValue: self currentProjectVersion ].
+]
+
+{ #category : #initialization }
 CMSpecModelComments >> initializeWidgets [
 	" Private - See superimplementor's comment "
 	
 	self instantiateModels: #(
 		versionName 			SpcLabeledTextField
 		creationDate 		SpcLabeledTextField
-		authorList 			CMGrowableAuthorList
+		authorList 			SpcLabeledTextArea
 		modelText 			SpcLabeledTextArea
 		toolbar 				SpcOneButtonToolbar
 		).
 	self focusOrder 
+		add: self versionName;
 		add: self authorList;
 		add: self toolbar.
 ]
@@ -141,7 +221,7 @@ CMSpecModelComments >> modelText: anObject [
 CMSpecModelComments >> title [
 	" Private - See superimplementor's comment "
 
-	^ 'Model Comments'
+	^ self translator tModelComments
 ]
 
 { #category : #accessing }

--- a/repository/Cormas-UI/CMSpecObject.class.st
+++ b/repository/Cormas-UI/CMSpecObject.class.st
@@ -87,6 +87,12 @@ CMSpecObject >> cormasModelClass [
 ]
 
 { #category : #accessing }
+CMSpecObject >> currentProject [ 
+
+	^ self projectManager currentProject 
+]
+
+{ #category : #accessing }
 CMSpecObject >> iconNamed: aSymbol [
 	" Answer a <Form> representing a Cormas icon "
 
@@ -96,6 +102,12 @@ CMSpecObject >> iconNamed: aSymbol [
 { #category : #callbacks }
 CMSpecObject >> openHelp [
 	self shouldBeImplemented.
+]
+
+{ #category : #accessing }
+CMSpecObject >> projectAnnouncer [
+
+	^ self projectManager announcer 
 ]
 
 { #category : #accessing }

--- a/repository/Cormas-UI/CMSpecProjectWindow.class.st
+++ b/repository/Cormas-UI/CMSpecProjectWindow.class.st
@@ -142,6 +142,24 @@ CMSpecProjectWindow >> initializeSimulationSubMenu: group [
 ]
 
 { #category : #initialization }
+CMSpecProjectWindow >> initializeSubscriptions [
+
+	self projectAnnouncer
+		when: CMProjectOpenAnnouncement
+		send: #updateStateOpened
+		to: self.
+	self projectAnnouncer
+		when: CMProjectNewAnnouncement
+		send: #updateStateNew
+		to: self.
+	self projectAnnouncer
+		when: CMProjectUpdateAnnouncement, CMProjectRenameAnnouncement
+		do: [ : ann | 
+				self windowTitle: self formattedWindowTitle.
+				self updateTitle. ]
+]
+
+{ #category : #initialization }
 CMSpecProjectWindow >> initializeVisualizationSubMenu: group [
 
 	group
@@ -155,7 +173,9 @@ CMSpecProjectWindow >> initializeVisualizationSubMenu: group [
 CMSpecProjectWindow >> initializeWidgets [
 	" Private - See superimplementor's comment "
 
-	self initializeApplication.
+	self 
+		initializeApplication;
+		initializeSubscriptions.
 	super initializeWidgets.
 	self simWindow: ((CMSpecSimulationContainer for: self projectManager)
 		owner: self;
@@ -451,6 +471,12 @@ CMSpecProjectWindow >> openVizSpace [
 	viz window extent: viz spaceView canvas extent + (20 @ 20).
 	viz spaceView canvas focusOnCenterScaled.
 	viz spaceView signalUpdate
+]
+
+{ #category : #accessing }
+CMSpecProjectWindow >> projectAnnouncer [
+
+	^ self projectManager announcer
 ]
 
 { #category : #accessing }
@@ -1176,7 +1202,9 @@ CMSpecProjectWindow >> updateStateNew [
 		menuEnableToolsGroup;
 		menuEnableVisualizationGroup;
 		menuEnableHelpGroup;
-		updateSimulationWindow
+		updateSimulationWindow;
+		windowTitle: self formattedWindowTitle;
+		updateTitle.
 ]
 
 { #category : #callbacks }
@@ -1190,7 +1218,9 @@ CMSpecProjectWindow >> updateStateOpened [
 		menuEnableToolsGroup;
 		menuEnableVisualizationGroup;
 		menuEnableHelpGroup;
-		updateSimulationWindow
+		updateSimulationWindow.
+	self windowTitle: self formattedWindowTitle.
+	self updateTitle.
 ]
 
 { #category : #callbacks }

--- a/repository/Cormas-UI/CMTranslator.class.st
+++ b/repository/Cormas-UI/CMTranslator.class.st
@@ -269,6 +269,7 @@ CMTranslator >> addTranslationsForENPart3 [
 		at: #tChangeModelComments put: 'Change model Comments';
 		at: #tWhichOpeningLocation put: 'Select open location';
 		at: #tOptions put: 'Options';
+		at: #tNoVersion put: 'No version';
 		yourself
 ]
 
@@ -507,6 +508,7 @@ CMTranslator >> addTranslationsForESPart3 [
 		at: #tHowToRunModel 					put: 'Como ejecutar este modelo';
 		at: #tChangeModelComments 			put: 'Modificar comentarios del modelo';
 		at: #tWhichOpeningLocation 			put: 'Seleccione la ubicacion del elemento';
+		at: #tNoVersion 						put: 'Sin versión';
 		yourself
 
 ]


### PR DESCRIPTION
…d Comments UI.

Fix requestModelOpenDialogFromLocalImage case where the user cancels selection of model
Use #cmAuthors instead of #authors which is taken by Pharo now
Use a simpler text area for CORMAS authors, easier to handle than the previous dynamic list.
Added methods in Model Comments UI for accessing the project metadata
Use announcements to update project window through subscriptions instead of requiring a reference to the window
Do not uses anymore #updateNewProject: for updating the title