### PR TITLE
Add tests for project features

### DIFF
--- a/repository/Cormas-Core/CMAbstractModel.class.st
+++ b/repository/Cormas-Core/CMAbstractModel.class.st
@@ -4155,7 +4155,11 @@ CMAbstractModel >> simNumero [
 { #category : #'accessing  - projectManager' }
 CMAbstractModel >> simWindow [
 
-^self projectManager ifNil:[nil] ifNotNil:[:pm| pm projectWindow simWindow simWindow ]
+	^ self projectManager 
+		ifNil: [ nil ] 
+		ifNotNil: [ : pm | pm projectWindow 
+			ifNil: [ nil ]
+			ifNotNil: [ : pw | pw simWindow simWindow ] ]
 ]
 
 { #category : #'- pov and info' }

--- a/repository/Cormas-Core/CMSimManager.class.st
+++ b/repository/Cormas-Core/CMSimManager.class.st
@@ -2763,6 +2763,13 @@ CMSimManager class >> separator [
 	^'-------'
 ]
 
+{ #category : #'replay-private' }
+CMSimManager class >> simNameStart [
+	"Return the begining part of each simName (=> 'sim_' )  "
+	
+	^'sim_'
+]
+
 { #category : #actions }
 CMSimManager >> accept [
 	
@@ -3627,9 +3634,9 @@ CMSimManager >> simName: aName [
 
 { #category : #'replay-private' }
 CMSimManager >> simNameStart [
-	"Return the begining part of each simName (=> 'sim_' )  "
+	" Return the begining part of each simName (=> 'sim_' )  "
 	
-	^'sim_'
+	^ self class simNameStart 
 ]
 
 { #category : #accessing }

--- a/repository/Cormas-Tests/CMAbstractModelTest.class.st
+++ b/repository/Cormas-Tests/CMAbstractModelTest.class.st
@@ -7,6 +7,19 @@ Class {
 	#category : #'Cormas-Tests'
 }
 
+{ #category : #test }
+CMAbstractModelTest >> cormasModelNamesForTests [
+
+	^ 'Demo_Aquifer
+Demo_Aggregates
+Conway
+Demo_ArcsNodes
+Diffuse
+FireModel
+DemoWayTo
+ECEC' lines
+]
+
 { #category : #'tests-accessing-entities' }
 CMAbstractModelTest >> newTestModel [
 	^ (CMTestModel
@@ -20,6 +33,12 @@ CMAbstractModelTest >> newTestModel [
 			neighbourhood: 4
 			closed: true;
 		yourself
+]
+
+{ #category : #test }
+CMAbstractModelTest >> sampleModelName [
+
+	^ 'CMXXXModel'
 ]
 
 { #category : #'tests-accessing-entities' }

--- a/repository/Cormas-Tests/CMEnvFileReaderTest.class.st
+++ b/repository/Cormas-Tests/CMEnvFileReaderTest.class.st
@@ -11,7 +11,7 @@ Class {
 CMEnvFileReaderTest >> createSampleEnvFile [
 
 	| sampleEnvFile |
-	sampleEnvFile := (CMResourceLocator new mapsPath: 'CormasModelForTest') / 'temp.env'.
+	sampleEnvFile := (CMResourceLocator new mapsPath: self sampleModelPath) / 'temp.env'.
 	sampleEnvFile writeStreamDo: [ :arg1 | arg1 nextPutAll: self sampleEnv ].
 	^ sampleEnvFile
 ]
@@ -49,6 +49,12 @@ dead'
 ]
 
 { #category : #accessing }
+CMEnvFileReaderTest >> sampleModelPath [
+	
+	^ 'CormasModelForTest'
+]
+
+{ #category : #running }
 CMEnvFileReaderTest >> setUp [
 	" See superimplementor's comment "
 
@@ -60,11 +66,12 @@ CMEnvFileReaderTest >> setUp [
 			yourself).
 ]
 
-{ #category : #accessing }
+{ #category : #running }
 CMEnvFileReaderTest >> tearDown [ 
 
+	self envFileReader fileReference ifNotNil: [ : envFile | envFile ensureDelete ].
+	(CMResourceLocator new modelPath: self sampleModelPath) ensureDeleteAll. 
 	super tearDown.
-	self envFileReader fileReference ifNotNil: [ : envFile | envFile ensureDelete ]
 ]
 
 { #category : #test }

--- a/repository/Cormas-Tests/CormasUITest.class.st
+++ b/repository/Cormas-Tests/CormasUITest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #CormasUITest,
 	#superclass : #TestCase,
-	#category : 'Cormas-Tests'
+	#category : #'Cormas-Tests'
 }
 
 { #category : #'create CMProjet' }
@@ -34,8 +34,8 @@ CormasUITest >> testCurrentStepInputTextOfSimWindowIsResetAfterOpeningAModel [
 	
 	20 timesRepeat: [ aCMProjectManager currentProject cormasModel runStep ].
 	
-	aCMProjectManager openImageProject: 'CMECECModel'.
-	aCMProjectManager updateNewProject: 'CMECECModel'.
+	aCMProjectManager openImageProject: #CMECECModel.
+	aCMProjectManager updateNewProject: #CMECECModel.
 	self assert: simWindow currentStepInputText text equals: 0.
 ]
 

--- a/repository/Cormas-UI-Tests/CMApplicationProjectTest.class.st
+++ b/repository/Cormas-UI-Tests/CMApplicationProjectTest.class.st
@@ -62,7 +62,7 @@ CMApplicationProjectTest >> testDefaultTranslatorClass [
 { #category : #test }
 CMApplicationProjectTest >> testModelNames [
 
-	self assert: self application modelNames equals: self cormasModelNamesForTests
+	self assertCollection: self application modelNames hasSameElements: self cormasModelNamesForTests
 ]
 
 { #category : #test }

--- a/repository/Cormas-UI-Tests/CMApplicationProjectTest.class.st
+++ b/repository/Cormas-UI-Tests/CMApplicationProjectTest.class.st
@@ -1,0 +1,72 @@
+"
+A CMApplicationProjectTest is a test class for testing the behavior of CMApplicationProject
+"
+Class {
+	#name : #CMApplicationProjectTest,
+	#superclass : #CMAbstractModelTest,
+	#instVars : [
+		'application'
+	],
+	#category : #'Cormas-UI-Tests-Project'
+}
+
+{ #category : #accessing }
+CMApplicationProjectTest >> application [
+	^ application
+]
+
+{ #category : #accessing }
+CMApplicationProjectTest >> application: anObject [
+	application := anObject
+]
+
+{ #category : #running }
+CMApplicationProjectTest >> setUp [
+	"Hooks that subclasses may override to define the fixture of test."
+
+	super setUp.
+	application := CMApplicationProject new.
+]
+
+{ #category : #running }
+CMApplicationProjectTest >> tearDown [
+	"Hooks that subclasses may override to define the fixture of test."
+
+	self.
+	super tearDown.	
+
+]
+
+{ #category : #test }
+CMApplicationProjectTest >> testCormasModel [
+
+	self assert: self application currentProject isNil.
+	self application currentProject: (CMProjectModel for: self newTestModel).
+	self assert: (self application cormasModel isKindOf: CMTestModel).
+	
+]
+
+{ #category : #test }
+CMApplicationProjectTest >> testDefaultProjectClass [
+
+	self assert: self application defaultProjectClass equals: CMProjectModel.
+
+]
+
+{ #category : #test }
+CMApplicationProjectTest >> testDefaultTranslatorClass [
+
+	self assert: self application defaultTranslatorClass equals: CMTranslator.
+]
+
+{ #category : #test }
+CMApplicationProjectTest >> testModelNames [
+
+	self assert: self application modelNames equals: self cormasModelNamesForTests
+]
+
+{ #category : #test }
+CMApplicationProjectTest >> testResourceLocator [
+
+	self assert: (self application resourceLocator isKindOf: CMResourceLocator)
+]

--- a/repository/Cormas-UI-Tests/CMProjectManagerTest.class.st
+++ b/repository/Cormas-UI-Tests/CMProjectManagerTest.class.st
@@ -1,0 +1,243 @@
+Class {
+	#name : #CMProjectManagerTest,
+	#superclass : #CMAbstractModelTest,
+	#instVars : [
+		'projectManager'
+	],
+	#category : #'Cormas-UI-Tests-Project'
+}
+
+{ #category : #'tests-accessing-entities' }
+CMProjectManagerTest >> newProjectManager [
+
+	^ CMProjectManager new 
+		currentProject: (CMProjectModel basicNew
+				initializeForModel: model named: 'Sample Model';
+				yourself);
+		yourself
+]
+
+{ #category : #accessing }
+CMProjectManagerTest >> projectManager [
+	^ projectManager
+]
+
+{ #category : #accessing }
+CMProjectManagerTest >> projectManager: anObject [
+	projectManager := anObject
+]
+
+{ #category : #test }
+CMProjectManagerTest >> projectModel [
+
+	^ self projectManager currentProject 
+]
+
+{ #category : #'tests-accessing-entities' }
+CMProjectManagerTest >> setUp [ 
+
+	super setUp.
+	CMApplicationProject release.
+	PFProjectSettings currentApplicationClass: CMApplicationProject.
+	model := self newTestModel.
+	projectManager := self newProjectManager.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testApplicationExtension [
+
+	self assert: (self projectManager applicationExtension isKindOf: String).
+	self assert: self projectManager applicationExtension equals: CMApplicationProject applicationExtension.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCodeGenerator [
+
+	self assert: (self projectManager codeGenerator isKindOf: CGStCormas)
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCormasModel [
+
+	self assert: (self projectManager cormasModel isKindOf: CMAbstractModel).
+	self projectManager cormasModel: nil.
+	self assert: self projectManager cormasModel isNil.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCormasModelAuthors [
+
+	| modelClass |
+	
+	self projectManager cormasModelAuthors: 'author1;author@cormas.org'.
+	modelClass := self projectModel cormasModelClass.
+	self assert: (modelClass respondsTo: #cmAuthors).
+	self assert: modelClass cmAuthors equals: 'author1;author@cormas.org'.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCormasModelClass [
+
+	self assert: (self projectManager cormasModelClass isKindOf: CMAbstractModel class).
+
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCormasModelComment [
+
+	| modelComment |
+	
+	modelComment := 'This is a model comment'.
+	self projectModel cormasModelComment: modelComment.
+	self assert: (self projectManager cormasModelClass respondsTo: #comments).
+	self assert: self projectManager cormasModelClass comments equals: modelComment.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCormasModelCreationDate [
+
+	| modelDate |
+	
+	modelDate := Date today asString.
+	self projectModel cormasModelCreationDate: modelDate.
+	self assert: (self projectManager cormasModelClass respondsTo: #creationDate).
+	self assert: self projectManager cormasModelClass creationDate equals: modelDate.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCormasModelName [
+
+	self assert: self projectManager cormasModelName equals: 'CMTestModel'
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCormasModelVersion [
+
+	| modelVersion |
+	
+	modelVersion := '1.0'.
+	self projectModel cormasModelVersion: modelVersion.
+	self assert: (self projectManager cormasModelClass respondsTo: #cmVersion).
+	self assert: self projectManager cormasModelClass cmVersion equals: modelVersion.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCormasModels [
+
+	self assert: self projectManager cormasModels equals: self cormasModelNamesForTests.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCormasOpenLocations [
+
+	self 
+		assert: self projectManager cormasOpenLocations 
+		equals: self projectManager cormasOpenLocationsMap keys.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCormasOpenLocationsMap [
+
+	self assert: (self projectManager cormasOpenLocationsMap isKindOf: Dictionary).
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCreateClassModelNamed [
+
+	| modelClassname |
+	
+	modelClassname := self sampleModelName.
+	self assert: ((self projectManager createClassModelNamed: modelClassname) isKindOf: Class).
+	self assert: (self class environment hasClassNamed: modelClassname).
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCurrentProjectAuthors [
+
+	| authors |
+	authors := 'author_name1;
+author_name2'.
+	self projectManager cormasModelAuthors: authors.
+	self assert: self projectManager currentProjectAuthors equals: authors.
+
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCurrentProjectHasAuthor [
+
+	self projectManager cormasModelAuthors: 'author_name'.
+	self assert: self projectManager currentProjectHasAuthor.
+
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCurrentProjectHasComments [
+
+	self projectManager cormasModelComment: 'comment 1'.
+	self assert: self projectManager currentProjectHasComments.
+
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCurrentProjectHasCreationDate [
+
+	self projectManager cormasModelCreationDate: Date today asString.
+	self assert: self projectManager currentProjectHasCreationDate.
+
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCurrentProjectHasVersion [
+
+	self projectManager cormasModelVersion: '1.0'.
+	self assert: self projectManager currentProjectHasVersion.
+
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testCurrentProjectVersion [
+
+	self projectManager cormasModelVersion: '1.0'.
+	self assert: self projectManager currentProjectVersion equals: '1.0'.
+
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testModelControlInitMethods [
+
+	self assert: (self projectManager modelControlInitMethods isKindOf: Array).
+	self assert: self projectManager modelControlInitMethods isEmpty.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testModelInitMethods [
+
+	self assert: (self projectManager modelInitMethods isKindOf: Array).
+	self assert: self projectManager modelInitMethods isEmpty.
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testModelProbesMethods [
+
+	self assert: (self projectManager modelProbesMethods isKindOf: Array).
+	self assert: self projectManager modelProbesMethods equals: #('Global>>numDeads' 'Global>>numAlives').
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testOpenImageProject [
+
+	self assert: ((self projectManager openImageProject: #CMECECModel) isKindOf: CMProjectManager).
+	self assert: self projectManager currentProject cormasModelClass equals: CMECECModel
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testProjectClass [
+
+	self assert: self projectManager projectClass equals: CMProjectModel
+]
+
+{ #category : #test }
+CMProjectManagerTest >> testResourceLocator [
+
+	self assert: (self projectManager resourceLocator isKindOf: CMResourceLocator)
+]

--- a/repository/Cormas-UI-Tests/CMProjectManagerTest.class.st
+++ b/repository/Cormas-UI-Tests/CMProjectManagerTest.class.st
@@ -220,7 +220,7 @@ CMProjectManagerTest >> testModelInitMethods [
 CMProjectManagerTest >> testModelProbesMethods [
 
 	self assert: (self projectManager modelProbesMethods isKindOf: Array).
-	self assert: self projectManager modelProbesMethods equals: #('Global>>numDeads' 'Global>>numAlives').
+	self assertCollection: self projectManager modelProbesMethods hasSameElements: #('Global>>numDeads' 'Global>>numAlives').
 ]
 
 { #category : #test }

--- a/repository/Cormas-UI-Tests/CMProjectManagerTest.class.st
+++ b/repository/Cormas-UI-Tests/CMProjectManagerTest.class.st
@@ -124,7 +124,7 @@ CMProjectManagerTest >> testCormasModelVersion [
 { #category : #test }
 CMProjectManagerTest >> testCormasModels [
 
-	self assert: self projectManager cormasModels equals: self cormasModelNamesForTests.
+	self assertCollection: self projectManager cormasModels hasSameElements: self cormasModelNamesForTests.
 ]
 
 { #category : #test }

--- a/repository/Cormas-UI-Tests/CMProjectModelTest.class.st
+++ b/repository/Cormas-UI-Tests/CMProjectModelTest.class.st
@@ -10,6 +10,15 @@ Class {
 	#category : #'Cormas-UI-Tests-Project'
 }
 
+{ #category : #running }
+CMProjectModelTest >> newTestModel [
+	" See superimplementor's comment "
+
+	^ super newTestModel 
+		projectManager: CMProjectManager new;
+		yourself
+]
+
 { #category : #accessing }
 CMProjectModelTest >> projectModel [
 	^ projectModel
@@ -25,7 +34,45 @@ CMProjectModelTest >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
 
 	super setUp.
-	self projectModel: (CMProjectModel for: self newTestModel)
+	self projectModel: (CMProjectModel for: self newTestModel).
+	CGSmalltalk new removeClass: #ToBeDeleted.
+]
+
+{ #category : #running }
+CMProjectModelTest >> tearDown [
+	"Hooks that subclasses may override to define the fixture of test."
+
+	CGSmalltalk new removeClass: self sampleModelName.
+	super tearDown.	
+
+]
+
+{ #category : #test }
+CMProjectModelTest >> testCodeGenerator [
+
+	self assert: (self projectModel codeGenerator isKindOf: CGStCormas).
+
+
+]
+
+{ #category : #test }
+CMProjectModelTest >> testCormasModel [
+
+	self assert: (self projectModel cormasModel isKindOf: CMAbstractModel).
+	self projectModel cormasModel: nil.
+	self assert: self projectModel cormasModel isNil.
+]
+
+{ #category : #test }
+CMProjectModelTest >> testCormasModelAuthors [
+
+	| modelAuthors |
+	
+	modelAuthors := 'Author1;author1@cormas.org
+Author2;author2@cormas.org'.
+	self projectModel cormasModelAuthors: modelAuthors.
+	self assert: (self projectModel cormasModelClass respondsTo: #cmAuthors).
+	self assert: self projectModel cormasModelClass cmAuthors equals: modelAuthors.
 ]
 
 { #category : #test }
@@ -37,10 +84,54 @@ CMProjectModelTest >> testCormasModelClass [
 ]
 
 { #category : #test }
+CMProjectModelTest >> testCormasModelComment [
+
+	| modelComment |
+	
+	modelComment := 'This is a model comment'.
+	self projectModel cormasModelComment: modelComment.
+	self assert: (self projectModel cormasModelClass respondsTo: #comments).
+	self assert: self projectModel cormasModelClass comments equals: modelComment.
+]
+
+{ #category : #test }
+CMProjectModelTest >> testCormasModelCreationDate [
+
+	| modelDate |
+	
+	modelDate := '01/01/1970'.
+	self projectModel cormasModelCreationDate: modelDate.
+	self assert: (self projectModel cormasModelClass respondsTo: #creationDate).
+	self assert: self projectModel cormasModelClass creationDate equals: modelDate.
+]
+
+{ #category : #test }
 CMProjectModelTest >> testCormasModelName [
 
 	self assert: (self projectModel cormasModelName isKindOf: String).
 	self assert: self projectModel cormasModelName equals: 'CMTestModel'.
+
+]
+
+{ #category : #test }
+CMProjectModelTest >> testCormasModelVersion [
+
+	| modelVersion |
+	
+	modelVersion := '1.0'.
+	self projectModel cormasModelVersion: modelVersion.
+	self assert: (self projectModel cormasModelClass respondsTo: #cmVersion).
+	self assert: self projectModel cormasModelClass cmVersion equals: modelVersion.
+]
+
+{ #category : #test }
+CMProjectModelTest >> testCreateClassModelNamed [
+
+	| modelClassname |
+	
+	modelClassname := self sampleModelName.
+	self assert: ((self projectModel createClassModelNamed: modelClassname) isKindOf: Class).
+	self assert: (self class environment hasClassNamed: modelClassname).
 
 ]
 
@@ -69,11 +160,29 @@ CMProjectModelTest >> testDefaultStdCormasModelName [
 ]
 
 { #category : #test }
+CMProjectModelTest >> testFindSimulationNamed [
+
+	self flag: #toDo. "Get simulation files "
+	"self should: [ self projectModel findSimulationNamed: 'noname' ] raise: Error."
+]
+
+{ #category : #test }
 CMProjectModelTest >> testHasCormasModelClass [
 
 	self assert: self projectModel hasCormasModelClass.
 
 
+]
+
+{ #category : #test }
+CMProjectModelTest >> testHasStoredSimulations [
+
+	self flag: #toDo. "Get simulation files "
+"	self deny: self projectModel hasStoredSimulations.
+	self application currentProject: (CMProjectModel basicNew
+				initializeForModel: model named: 'Sample Model';
+				yourself).
+	self deny: self application hasStoredSimulations."
 ]
 
 { #category : #test }
@@ -85,9 +194,41 @@ CMProjectModelTest >> testProjectName [
 ]
 
 { #category : #test }
+CMProjectModelTest >> testStoredSimulations [
+
+	self flag: #toDo. "Get simulation files "
+	"self assert: self projectModel storedSimulations isEmpty"
+]
+
+{ #category : #test }
 CMProjectModelTest >> testUserProvidedName [
 
 	self assert: (self projectModel userProvidedName isKindOf: String).
 	self assert: self projectModel userProvidedName equals: self projectModel defaultCormasModelName.
 
+]
+
+{ #category : #test }
+CMProjectModelTest >> testValidateCormasModelName [
+
+	self assert: (self projectModel validateCormasModelName: 'CMPruebaModel') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: '_CMPruebaModel') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: 'CMPruebaModel_') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: 'CM_PruebaModel') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: '_CMPruebaModel_') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: '_CM_Prueba_Model_') equals: 'CMPruebaModel'.
+
+	self assert: (self projectModel validateCormasModelName: 'CMPruebaModel') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: '-CMPruebaModel-') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: 'CMPruebaModel-') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: 'CM-PruebaModel') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: '-_CMPruebaModel-') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: '-CM-Prueba_Model-') equals: 'CMPruebaModel'.
+
+	self assert: (self projectModel validateCormasModelName: 'CMPruebaModel') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: ' CMPruebaModel ') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: 'CMPruebaModel ') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: 'CM PruebaModel') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: ' CMPruebaModel ') equals: 'CMPruebaModel'.
+	self assert: (self projectModel validateCormasModelName: ' CM Prueba Model ') equals: 'CMPruebaModel'.
 ]

--- a/repository/Cormas-UI/CMApplicationProject.class.st
+++ b/repository/Cormas-UI/CMApplicationProject.class.st
@@ -35,6 +35,13 @@ CMApplicationProject class >> applicationName [
 	^ 'CORMAS Application'
 ]
 
+{ #category : #testing }
+CMApplicationProject >> cormasModel [
+	" Answer the receiver's current project model, a <CMAbstractModel> instance "
+
+	^ self currentProject cormasModel 
+]
+
 { #category : #accessing }
 CMApplicationProject >> defaultProjectClass [
 	" Private - See superimplementor's comment "
@@ -47,27 +54,6 @@ CMApplicationProject >> defaultTranslatorClass [
 	" Answer the default translation class for the receiver "
 
 	^ CMTranslator
-]
-
-{ #category : #'accessing-simulations' }
-CMApplicationProject >> findSimulationNamed: aName [
-	" Answer <true> if the dump folder has stored simulations "
-
-	^ (self resourceLocator dumpPath: self cormasModel class name)
-		removeAllSuchThat: [ : txt | (txt beginsWith: self simNameStart) not ].
-
-]
-
-{ #category : #testing }
-CMApplicationProject >> hasStoredSimulations [
-	" Answer <true> if the dump folder has stored simulations "
-
-	| directoryContent |
-
-	self terminateAllProcesses.
-	(directoryContent := self resourceLocator dumpPath: self cormasModel class name)
-		removeAllSuchThat: [ : txt | (txt beginsWith: self simNameStart) not ].
-	^ directoryContent isEmpty
 ]
 
 { #category : #'accessing-path' }
@@ -88,29 +74,17 @@ CMApplicationProject >> resourceLocator: anObject [
 	resourceLocator := anObject
 ]
 
-{ #category : #'accessing-simulations' }
-CMApplicationProject >> storedSimulations [
-	" Answer <true> if the dump folder has stored simulations "
-
-	^ (self resourceLocator dumpPath: self cormasModel class name)
-		removeAllSuchThat: [ : txt | (txt beginsWith: self simNameStart) not ].
-
-]
-
 { #category : #convenience }
 CMApplicationProject >> terminateAllProcesses [
 	"Terminate all the processes"
-	
-	processReplayForward isNil
-		ifFalse:
-			[processReplayForward terminate.
-			processReplayForward := nil].
-	processReplayBackward isNil
-		ifFalse:
-			[processReplayBackward terminate.
-			processReplayBackward := nil].
-	processRun isNil
-		ifFalse:
-			[processRun terminate.
-			processRun := nil]
+
+	processReplayForward
+		ifNotNil: [ processReplayForward terminate.
+			processReplayForward := nil ].
+	processReplayBackward
+		ifNotNil: [ processReplayBackward terminate.
+			processReplayBackward := nil ].
+	processRun
+		ifNotNil: [ processRun terminate.
+			processRun := nil ]
 ]

--- a/repository/Cormas-UI/CMProjectManager.class.st
+++ b/repository/Cormas-UI/CMProjectManager.class.st
@@ -51,14 +51,21 @@ CMProjectManager >> codeGenerator [
 
 { #category : #accessing }
 CMProjectManager >> cormasModel [
-	" Answer a <CMProjectModel> which is a Cormas model instance "
+	" Answer a <CMAbstractModel> which is a Cormas model instance "
 
 	^ self currentProject cormasModel
 ]
 
 { #category : #accessing }
+CMProjectManager >> cormasModel: aCMAbstractModel [
+	" Set aCMAbstractModel which is a Cormas model instance "
+
+	self currentProject cormasModel: aCMAbstractModel
+]
+
+{ #category : #accessing }
 CMProjectManager >> cormasModelAuthors: aString [
-	" Set aString with author names (one by line) to the receiver's model "
+	" Set aString with author names (one by line) to the receiver's current project model "
 
 	self currentProject cormasModelAuthors: aString
 ]
@@ -68,6 +75,14 @@ CMProjectManager >> cormasModelClass [
 	" Answer a <Class> representing the model class of the receiver's current project "
 
 	^ self currentProject cormasModelClass
+]
+
+{ #category : #accessing }
+CMProjectManager >> cormasModelComment: aString [
+	" Set the receiver's model comments to aString "
+
+	self currentProject cormasModelComment: aString
+
 ]
 
 { #category : #accessing }
@@ -85,14 +100,6 @@ CMProjectManager >> cormasModelName [
 ]
 
 { #category : #accessing }
-CMProjectManager >> cormasModelText: aString [
-	" Set the receiver's model comments to aString "
-
-	self currentProject cormasModelText: aString
-
-]
-
-{ #category : #accessing }
 CMProjectManager >> cormasModelVersion: aString [
 	" Set the receiver's model version number to aString.
 	ToDo: Currently the version number format is not normalized/validated "
@@ -103,7 +110,7 @@ CMProjectManager >> cormasModelVersion: aString [
 
 { #category : #accessing }
 CMProjectManager >> cormasModels [
-	" Answer a <Collection> of <String> with receiver's available models "
+	" Answer a <Collection> of <String> with the application available models "
 	
 	^ self application modelNames
 ]
@@ -121,10 +128,10 @@ CMProjectManager >> cormasOpenLocationsMap [
 	" Answer a Collection of valid locations for opening a Cormas model "
 
 	^ Dictionary new
-		at: 'Local Disk' 		put: #requestModelOpenFromLocalDisk;
-		at: 'URL' 				put: #requestModelOpenFromURL;
-		at: 'Local image' 		put: #requestModelOpenFromLocalImage;
-		at: 'Remote image'		put: #requestModelOpenFromRemoteImage;
+		at: self translator tLocalStorage 		put: #requestModelOpenFromLocalDisk;
+		at: 'URL' 										put: #requestModelOpenFromURL;
+		at: self translator tLocalImage			put: #requestModelOpenFromLocalImage;
+		at: self translator tRemoteImage 			put: #requestModelOpenFromRemoteImage;
 		yourself 
 ]
 
@@ -180,14 +187,14 @@ CMProjectManager >> currentProjectHasCreationDate [
 CMProjectManager >> currentProjectHasVersion [
 	" Answer <true> if receiver's contains a version name "
 
-	^  self currentProject cormasModelClass respondsTo: #version
+	^  self currentProject cormasModelClass respondsTo: #cmVersion
 ]
 
 { #category : #testing }
 CMProjectManager >> currentProjectVersion [
 	" Answer a <String> containing receiver's current version name. If no version is found, answer a descriptive string reflecting the situation (i.e. 'no version') "
 
-	^ [ self currentProject cormasModelClass version ]
+	^ [ self currentProject cormasModelClass cmVersion ]
 	on: MessageNotUnderstood 
 	do: [ : ex | self translator tNoVersion ]
 
@@ -262,11 +269,10 @@ CMProjectManager >> openEditAttributes [
 CMProjectManager >> openImageProject: modelName [
 	" Open the project of the modelClass "
 
-	self
-		currentProject:
-			(CMProjectModel basicNew
-				initializeForModel: modelName asClass new named: modelName;
-				yourself)
+	self currentProject: (CMProjectModel basicNew
+		initializeForModel: (self class environment at: modelName) new
+			named: modelName;
+			yourself)
 ]
 
 { #category : #callbacks }
@@ -419,6 +425,23 @@ CMProjectManager >> updateStateInit [
 		menuDisableSimulationGroup;
 		menuDisableToolsGroup;
 		menuDisableHelpGroup.
+]
+
+{ #category : #callbacks }
+CMProjectManager >> updateStateNew [
+
+	self notifyEvent:	'Action: New'.
+	self announcer announce: CMProjectNewAnnouncement new.
+	self informMessage: self translator tProjectNewSuccess.
+]
+
+{ #category : #callbacks }
+CMProjectManager >> updateStateOpened [
+	" Private - This callback evaluate after the handleEvent: was fired "
+
+	self notifyEvent:	'Action: Opened'.
+	self announcer announce: CMProjectOpenAnnouncement new.
+	self informMessage: self translator tProjectOpenSuccess.
 ]
 
 { #category : #utilities }

--- a/repository/Cormas-UI/CMProjectModel.class.st
+++ b/repository/Cormas-UI/CMProjectModel.class.st
@@ -89,6 +89,17 @@ CMProjectModel >> cormasModelClass: aClass [
 ]
 
 { #category : #accessing }
+CMProjectModel >> cormasModelComment: aString [ 
+	" See comment in CMProjectManager>>cormasModelComment: "
+
+	self codeGenerator 
+		generateMethod: aString 
+		selector: #comments 
+		inClass: self cormasModelClass class.
+
+]
+
+{ #category : #accessing }
 CMProjectModel >> cormasModelCreationDate: aString [ 
 
 	self codeGenerator
@@ -107,22 +118,11 @@ CMProjectModel >> cormasModelName [
 ]
 
 { #category : #accessing }
-CMProjectModel >> cormasModelText: aString [ 
-	" See comment in CMProjectManager>>cormasModelText: "
-
-	self codeGenerator 
-		generateMethod: aString 
-		selector: #comments 
-		inClass: self cormasModelClass class.
-
-]
-
-{ #category : #accessing }
 CMProjectModel >> cormasModelVersion: aString [ 
 
 	self codeGenerator
 		generateMethod: aString 
-		selector: #version 
+		selector: #cmVersion 
 		inClass: self cormasModelClass class
 ]
 
@@ -171,11 +171,26 @@ CMProjectModel >> defaultStdCormasModelName [
 				<< 'Model' ]
 ]
 
+{ #category : #'accessing-simulations' }
+CMProjectModel >> findSimulationNamed: aName [
+	" Answer <true> if the dump folder has stored simulations "
+
+	^ self storedSimulations detect: [ : simName | simName = aName ]
+
+]
+
 { #category : #testing }
 CMProjectModel >> hasCormasModelClass [
 	" Answer <true> if receiver has configured a Cormas model "
 	
 	^ self cormasModelClass notNil
+]
+
+{ #category : #testing }
+CMProjectModel >> hasStoredSimulations [
+	" Answer <true> if the receiver has a project opened and the project's dump folder has stored simulations, <false> otherwise "
+
+	^ self storedSimulations notEmpty
 ]
 
 { #category : #'initialize - release' }
@@ -204,6 +219,22 @@ CMProjectModel >> projectName [
 ]
 
 { #category : #accessing }
+CMProjectModel >> resourceLocator [
+	" Answer the application's resource locator "
+	
+	^ self application resourceLocator
+]
+
+{ #category : #'accessing-simulations' }
+CMProjectModel >> storedSimulations [
+	" Answer a <Collection> with the receiver's current model stored simulations "
+
+	^ (self resourceLocator dumpPath: self cormasModel class name) 
+		allChildrenMatching: CMSimManager simNameStart , '*'
+
+]
+
+{ #category : #accessing }
 CMProjectModel >> userProvidedName [
 	" Answer a <String> with the receiver's name as provided by the user on creation "
 
@@ -215,8 +246,7 @@ CMProjectModel >> validateCormasModelName: modelName [
 	" Answer a <String> with modelName as valid Smalltalk class name "
 
 	| validClassName |
-	
 	(validClassName := self codeGenerator validateClassName: modelName) ~= modelName
-		ifTrue: [ self alertMessage: self translator tModifiedModelName  ].
+		ifTrue: [ self crTrace: modelName , ': ' , self translator tModifiedModelName , validClassName ].
 	^ validClassName
 ]

--- a/repository/Cormas-UI/CMTranslator.class.st
+++ b/repository/Cormas-UI/CMTranslator.class.st
@@ -262,14 +262,17 @@ CMTranslator >> addTranslationsForENPart3 [
 	" Private - See superimplementor's comment "
 
 	^ (self translatorClass forLanguage: #EN) translationMap
-		at: #tDistributeAsServer put: 'Distribute (act as a server)';
-		at: #tDistributeAsClient put: 'Distribute (act as a client)';
-		at: #tAboutModel put: 'About this model';
-		at: #tHowToRunModel put: 'How to run this model';
-		at: #tChangeModelComments put: 'Change model Comments';
-		at: #tWhichOpeningLocation put: 'Select open location';
-		at: #tOptions put: 'Options';
-		at: #tNoVersion put: 'No version';
+		at: #tDistributeAsServer 		put: 'Distribute (act as a server)';
+		at: #tDistributeAsClient 		put: 'Distribute (act as a client)';
+		at: #tAboutModel 					put: 'About this model';
+		at: #tHowToRunModel 				put: 'How to run this model';
+		at: #tChangeModelComments 		put: 'Change model Comments';
+		at: #tWhichOpeningLocation 		put: 'Select open location';
+		at: #tOptions 						put: 'Options';		
+		at: #tNoVersion 				put: 'No version';
+		at: #tLocalStorage 				put: 'Local disk';
+		at: #tLocalImage 					put: 'Local image';
+		at: #tRemoteImage 					put: 'Remote image';
 		yourself
 ]
 
@@ -509,6 +512,9 @@ CMTranslator >> addTranslationsForESPart3 [
 		at: #tChangeModelComments 			put: 'Modificar comentarios del modelo';
 		at: #tWhichOpeningLocation 			put: 'Seleccione la ubicacion del elemento';
 		at: #tNoVersion 						put: 'Sin versión';
+		at: #tLocalStorage 					put: 'Almacenamiento local';
+		at: #tLocalImage 						put: 'Imagen local';
+		at: #tRemoteImage 						put: 'Imagen remota';
 		yourself
 
 ]


### PR DESCRIPTION
Don't use alertMessage: for testing, use instead #crTrace:
cormasModelText: -> cormasModelComment:
Added project model tests
Added project manager #cormasModel:
Fixed comments
Use #cmAuthors instead of #authors to prevent collisions
Use #cmVersion instead of #version to prevent collisions
Added some translations
Added tests
Add proper cleaning of sampleModelPath in EnvFileReader test
authors -> #cmAuthors in ProjectModelTest
Add application project tests
Add project manager tests
Add convenience methods.
Minor refactorings.
Move simulations methods from application to project since a project has simulations, and not the application.