### PR TITLE
Add #migrateProjects to simplify model to project migration

### DIFF
--- a/repository/Cormas-UI/CMApplicationProject.class.st
+++ b/repository/Cormas-UI/CMApplicationProject.class.st
@@ -48,12 +48,14 @@ CMApplicationProject class >> applicationVersion [
 
 { #category : #accessing }
 CMApplicationProject class >> createUserDirectories [
+	" Create the demos location <FileReference> "
+
 	| baseLocation |
 	(baseLocation := CMApplicationPreferences settingBaseLocation asFileReference) exists
 		ifTrue: [ ^ self ].
 	baseLocation ensureCreateDirectory.
 	(baseLocation / 'demos') ensureCreateDirectory.
-	(baseLocation / 'preferences') ensureCreateDirectory
+	(baseLocation / 'preferences') ensureCreateDirectory.
 ]
 
 { #category : #accessing }

--- a/repository/Cormas-UI/CMModel2ProjectMigrator.class.st
+++ b/repository/Cormas-UI/CMModel2ProjectMigrator.class.st
@@ -21,10 +21,12 @@ Class {
 }
 
 { #category : #examples }
-CMModel2ProjectMigrator class >> example [ 
+CMModel2ProjectMigrator class >> migrateProjects [ 
 	<example>
 	
-	self new buildProjects
+	self new 
+		buildProjects;
+		moveProjects
 ]
 
 { #category : #building }
@@ -111,6 +113,15 @@ CMModel2ProjectMigrator >> metadataFilename [
 	" Answer a <String> with the name of the file which stores metadata information about a project "
 
 	^ CMProjectFile metadataFilename 
+]
+
+{ #category : #building }
+CMModel2ProjectMigrator >> moveProjects [
+	" Move recently generated projects to base location "
+
+	CMApplicationProject createUserDirectories.
+	(FileSystem workingDirectory allChildrenMatching: '*Model.zip') do: [ : modelRef |
+		modelRef moveTo: CMResourceLocator demosPath ]
 ]
 
 { #category : #building }


### PR DESCRIPTION
Move new demo created projects to base location.

Use

```smalltalk
CMModel2ProjectMigrator migrateProjects
```