### PR TITLE
Implements save projects on closing from the UI in #querySaveProject

### DIFF
--- a/repository/Cormas-Core/CMResourceLocator.class.st
+++ b/repository/Cormas-Core/CMResourceLocator.class.st
@@ -52,6 +52,13 @@ CMResourceLocator class >> preferencesPath [
 	^ CMApplicationProject baseDirectory / 'preferences'
 ]
 
+{ #category : #accessing }
+CMResourceLocator class >> userProjectsPath [
+	" Answer a <FileReference> with the receiver's path to the user projects directory "
+
+	^ CMApplicationProject baseDirectory / 'projects'
+]
+
 { #category : #public }
 CMResourceLocator class >> workingDirectory [
 	" Answer a <String> with the default directory "

--- a/repository/Cormas-UI/CMApplicationProject.class.st
+++ b/repository/Cormas-UI/CMApplicationProject.class.st
@@ -55,13 +55,11 @@ CMApplicationProject class >> baseDirectory [
 
 { #category : #accessing }
 CMApplicationProject class >> createUserDirectories [
-	" Create the demos location <FileReference> "
+	" Create directories for storing CORMAS files in this system "
 
-	self baseDirectory exists
-		ifTrue: [ ^ self ].
 	self baseDirectory ensureCreateDirectory.
-	CMResourceLocator demosPath ensureCreateDirectory.
-	CMResourceLocator preferencesPath ensureCreateDirectory.
+	#(#demosPath #userProjectsPath #preferencesPath) 
+		do: [ : pathSym | (CMResourceLocator perform: pathSym) ensureCreateDirectory ]
 ]
 
 { #category : #accessing }

--- a/repository/Cormas-UI/CMModel2ProjectMigrator.class.st
+++ b/repository/Cormas-UI/CMModel2ProjectMigrator.class.st
@@ -15,7 +15,8 @@ Class {
 	#superclass : #CMObject,
 	#instVars : [
 		'currentModel',
-		'outputDirectory'
+		'outputDirectory',
+		'destinationPath'
 	],
 	#category : #'Cormas-UI-Project'
 }
@@ -24,13 +25,22 @@ Class {
 CMModel2ProjectMigrator class >> migrateModels [ 
 	<example>
 	
-	self new 
-		buildProjects;
-		moveProjects
+	Cursor wait showWhile: [ 
+		self new 
+			destinationPath: CMResourceLocator demosPath;
+			buildProjects;
+			moveProjects ]
 ]
 
 { #category : #building }
-CMModel2ProjectMigrator >> buildForModel: modelClass [
+CMModel2ProjectMigrator >> buildForModel: aCMProjectModel [
+	" Creates a CORMAS project file, answer a <FileReference> to the new created project "
+
+	self buildForModelClass: aCMProjectModel cormasModelClass
+]
+
+{ #category : #building }
+CMModel2ProjectMigrator >> buildForModelClass: modelClass [
 	" Creates a CORMAS project file, answer a <FileReference> to the new created project "
 
 	currentModel := CMProjectModel basicNew
@@ -88,7 +98,7 @@ CMModel2ProjectMigrator >> buildProjects [
 
 	'Model2Project: Building project files...' traceCr.
 	CMAbstractModel subclassesDo: [ :modelClass |
-			self buildForModel: modelClass.
+			self buildForModelClass: modelClass.
 			self buildProjectFile ].
 	'Model2Project: Done building project files...' traceCr.
 ]
@@ -104,10 +114,30 @@ CMModel2ProjectMigrator >> currentModel: anObject [
 ]
 
 { #category : #defaults }
+CMModel2ProjectMigrator >> defaultDestinationPath [
+	" Private - By default the destination path it is the user projects directory "
+	
+	^ CMResourceLocator userProjectsPath
+]
+
+{ #category : #defaults }
 CMModel2ProjectMigrator >> defaultOutputDirectory [
 	" Private - Answer the default <String> with the name of the directory serving as temporary location where to write project files before being compressed "
 	
 	^ 'cormas_project'
+]
+
+{ #category : #private }
+CMModel2ProjectMigrator >> destinationPath [
+	" Answer a <FileReference> with the destination where projects should be migrated/written "
+
+	^ destinationPath
+		ifNil: [ destinationPath := self defaultDestinationPath ]
+]
+
+{ #category : #accessing }
+CMModel2ProjectMigrator >> destinationPath: anObject [
+	destinationPath := anObject
 ]
 
 { #category : #writing }
@@ -141,7 +171,7 @@ CMModel2ProjectMigrator >> moveProject: aFileReference [
 	
 	[	
 		self traceCrTab: 'Model2Project: Moving project file...' , aFileReference fullName. 
-		aFileReference moveTo: CMResourceLocator demosPath.
+		aFileReference moveTo: self destinationPath.
 		self traceCrTab: 'Model2Project: Done moving project file...' , aFileReference fullName. 
 	]
 	on: FileExists
@@ -149,6 +179,13 @@ CMModel2ProjectMigrator >> moveProject: aFileReference [
 		self traceCrTab: 'Model2Project: Deleting project file ' , ex fullName. 
 		ex ensureDelete.
 		ex retry. ]
+]
+
+{ #category : #private }
+CMModel2ProjectMigrator >> moveProjectFile [
+	" Private - Move aFileReference to the system demos/ path "
+	
+	self moveProject: FileSystem workingDirectory / self currentModel fileName
 ]
 
 { #category : #building }

--- a/repository/Cormas-UI/CMProjectManager.class.st
+++ b/repository/Cormas-UI/CMProjectManager.class.st
@@ -31,6 +31,13 @@ CMProjectManager >> applicationExtension [
 	^ self applicationClass applicationExtension  
 ]
 
+{ #category : #callbacks }
+CMProjectManager >> cleanEnvironment [
+	" These 3 steps are necessary because WeakAnnouncements hanging around "
+
+	3 timesRepeat: [ Smalltalk garbageCollect ].
+]
+
 { #category : #'code-generation' }
 CMProjectManager >> codeGenerator [
 	" Answer the receiver's Code Generator "
@@ -233,17 +240,26 @@ CMProjectManager >> defaultCormasOpener [
 ]
 
 { #category : #callbacks }
-CMProjectManager >> doPostCloseActions [
+CMProjectManager >> deleteProject [
+	" Private - Delete the current project from this system and unset its references "
 
-	self announcer unsubscribe: self currentProject.
-	self fsm handleEvent: #actionClose.
-	self projectWindow quitSubApplicationWindows.
-
-	" These 3 steps are necessary because WeakAnnouncements hanging around "
+	(RGContainer packageOfClass: self cormasModelClass) realPackage removeFromSystem.
 	self currentProject release.
 	self currentProject: nil.
-	3 timesRepeat: [ Smalltalk garbageCollect ].
+]
 
+{ #category : #callbacks }
+CMProjectManager >> doPostCloseActions [
+	" Private - See superimplementor's comment "
+
+	self querySaveProject.
+
+	Cursor wait showWhile: [
+		self announcer unsubscribe: self currentProject.
+		self fsm handleEvent: #actionClose.
+		self projectWindow quitSubApplicationWindows.
+		self deleteProject.	
+		self cleanEnvironment ].
 ]
 
 { #category : #callbacks }
@@ -346,6 +362,14 @@ CMProjectManager >> opener: anObject [
 CMProjectManager >> projectClass [
 
 	^ CMProjectModel
+]
+
+{ #category : #callbacks }
+CMProjectManager >> querySaveProject [
+	" Private - Request saving project if there are unsaved changes "
+	
+	(self currentProject requiresSaving and: [ self confirm: self translator tQuerySaveProject ])
+		ifTrue: [ self saveProject ].
 ]
 
 { #category : #accessing }

--- a/repository/Cormas-UI/CMProjectModel.class.st
+++ b/repository/Cormas-UI/CMProjectModel.class.st
@@ -309,13 +309,6 @@ CMProjectModel >> definedCormasVersions [
 	^ Array with: self
 ]
 
-{ #category : #accessing }
-CMProjectModel >> fileReference [ 
-	" Answer the receiver's project <FileReference> "
-
-	^ self info fileReference
-]
-
 { #category : #'accessing-simulations' }
 CMProjectModel >> findSimulationNamed: aName [
 	" Answer <true> if the dump folder has stored simulations "
@@ -400,6 +393,18 @@ CMProjectModel >> initializeForModel: aCormasModel named: aString [
 	self cormasModelClass: aCormasModel class.
 	self initializeEvents.
 
+]
+
+{ #category : #testing }
+CMProjectModel >> isModified [
+	" See superimplementor's comment "
+	
+	| opener imageSnap originalFileSnap |
+	
+	imageSnap := (RPackageOrganizer default packageOf: self cormasModel class) mcPackage snapshot.
+	opener := CMProjectOpener newFrom: self projectManager.
+	originalFileSnap := (MCStReader on: opener tryReadSourceFromProject) snapshot.
+	^ imageSnap ~= originalFileSnap
 ]
 
 { #category : #accessing }
@@ -488,6 +493,20 @@ CMProjectModel >> resourceLocator [
 	" Answer the application's resource locator "
 	
 	^ self application resourceLocator
+]
+
+{ #category : #private }
+CMProjectModel >> saveProjectFile [
+
+	| modelSaver |
+	
+	'Saving project file...' traceCr.
+	modelSaver := CMModel2ProjectMigrator new.
+	modelSaver 
+		buildForModel: self;
+		buildProjectFile;
+		moveProjectFile.
+	'Done saving project.'
 ]
 
 { #category : #accessing }

--- a/repository/Cormas-UI/CMProjectOpener.class.st
+++ b/repository/Cormas-UI/CMProjectOpener.class.st
@@ -90,7 +90,7 @@ CMProjectOpener >> openProject: aFileReference [
 	self tryOpenFromFile: aFileReference.
 	openStatus := true.
 	self currentProject: (CMProjectModel basicNew
-		fileName: aFileReference fullName;
+		fileReference: aFileReference;
 		projectManager: self projectManager;
 		initializeForModel: (self class environment at: self modelMainClass) new
 			named: self modelName;
@@ -121,6 +121,20 @@ CMProjectOpener >> tryReadSourceFromFile: fileRef [
 
 	[ 	
 		zipFileSys := self validateProjectFile: fileRef.
+		^ self modelFile readStream 
+	]
+	on: Error
+	do: [ : ex | 
+		self handleFileInException: ex.
+		openStatus := false ].
+]
+
+{ #category : #callbacks }
+CMProjectOpener >> tryReadSourceFromProject [
+	" Private - Try to open and read source code for the model currently opened in the receiver's project manager. Answer a <ReadStream> "
+
+	[ 	
+		zipFileSys := self validateProjectFile: self projectManager currentProjectFileReference.
 		^ self modelFile readStream 
 	]
 	on: Error

--- a/repository/Cormas-UI/FileReference.extension.st
+++ b/repository/Cormas-UI/FileReference.extension.st
@@ -6,7 +6,7 @@ FileReference >> asCormasProjectModelForPreview [
 
 	^ (CMProjectOpener new validateProjectFile: self) 
 		asCormasProjectModelForPreview
-		fileName: self fullName;
+		fileReference: self;
 		yourself
 ]
 


### PR DESCRIPTION
Deletes a project (package) from the image after closed.
If there is a difference between the code in the image and the stock demo code, raise a confirmation dialog to ask if the user wish to save the modified project. The saved project is saved in the $HOME/CORMAS/projects path. See #isModified
Add #userProjectsPath, #destinationPath and other necessary method to save a project on demand to the model migrator.