### PR TITLE
asPopupText is not necessary

### DIFF
--- a/repository/Cormas-Core/CMEntity.class.st
+++ b/repository/Cormas-Core/CMEntity.class.st
@@ -1280,6 +1280,17 @@ Example: GroupLocation superClassesUntilEntity"
 	^self superClassesUntil: CMEntity
 ]
 
+{ #category : #converting }
+CMEntity >> asString [
+	" Private - See superimplementor's comment "
+
+	^ String streamContents: [ : stream |
+		stream 
+			<< 'id: ';
+			<< id asString ]
+	
+]
+
 { #category : #displaying }
 CMEntity >> center: x [
 	"do nothing"

--- a/repository/Cormas-Core/CMSpatialEntityCell.class.st
+++ b/repository/Cormas-Core/CMSpatialEntityCell.class.st
@@ -17,6 +17,17 @@ CMSpatialEntityCell class >> isCellularAutomatonClass [
 	^ true
 ]
 
+{ #category : #converting }
+CMSpatialEntityCell >> asString [
+	" Private - See superimplementor's comment "
+
+	^ String streamContents: [ : stream |
+		stream 
+			<< 'State: ';
+			<< self state asString ]
+	
+]
+
 { #category : #accessing }
 CMSpatialEntityCell >> bufferState [
 	^ bufferState

--- a/repository/Cormas-Model-Conway/CMConwayCell.class.st
+++ b/repository/Cormas-Model-Conway/CMConwayCell.class.st
@@ -37,14 +37,6 @@ CMConwayCell class >> state_default [
 	^ nil
 ]
 
-{ #category : #printing }
-CMConwayCell >> asPopupText [
-	^ String streamContents: [ : stream |
-		stream 
-			<< 'State: ';
-			<< self state asString ]
-]
-
 { #category : #init }
 CMConwayCell >> initAllDead [
 

--- a/repository/Cormas-Model-DemoAggregates/CMDemoAggregatesPlot.class.st
+++ b/repository/Cormas-Model-DemoAggregates/CMDemoAggregatesPlot.class.st
@@ -101,11 +101,13 @@ CMDemoAggregatesPlot class >> tree_type [
 ]
 
 { #category : #converting }
-CMDemoAggregatesPlot >> asPopupText [
-	" Answer a <String> with the receiver's details "
+CMDemoAggregatesPlot >> asString [
+	" Private - See superimplementor's comment "
 
 	^ String streamContents: [ : stream |
 		stream 
+			<< super asString;
+			cr;
 			<< 'tree: ';
 			<< tree asString ]
 ]

--- a/repository/Cormas-Model-ECEC/CMECECVegetationUnit.class.st
+++ b/repository/Cormas-Model-ECEC/CMECECVegetationUnit.class.st
@@ -67,11 +67,13 @@ CMECECVegetationUnit class >> state_default [
 ]
 
 { #category : #converting }
-CMECECVegetationUnit >> asPopupText [
-	" Answer a <String> with the receiver's details "
+CMECECVegetationUnit >> asString [
+	" Private - See superimplementor's comment "
 
 	^ String streamContents: [ : stream |
 		stream 
+			<< super asString;
+			cr;
 			<< 'biomass: ';
 			<< (biomass truncateTo: 0.005) asString ]
 ]

--- a/repository/Cormas-Model-Stupid/CMStupidCell.class.st
+++ b/repository/Cormas-Model-Stupid/CMStupidCell.class.st
@@ -25,6 +25,18 @@ CMStupidCell class >> maxFoodProductionRate: aFloat [
 ]
 
 { #category : #accessing }
+CMStupidCell >> asString [
+	" Private - See superimplementor's comment "
+
+	^ String streamContents: [ : stream |
+		stream 
+			<< super asString;
+			cr;
+			<< 'food: ';
+			<< food asString ]
+]
+
+{ #category : #accessing }
 CMStupidCell >> food [
 	^ food ifNil: [ food :=  0.1]
 ]

--- a/repository/Cormas-UI-Roassal3/CMR3SpaceView.class.st
+++ b/repository/Cormas-UI-Roassal3/CMR3SpaceView.class.st
@@ -154,7 +154,7 @@ CMR3SpaceView >> configureLayoutOn: aRSGroup [
 CMR3SpaceView >> configurePopUpOn: theCellViews [
 
 	| popUp |
-	popUp := RSPopup text: [ : aCMEntity | aCMEntity asPopupText ].
+	popUp := RSPopup text: [ : aCMEntity | aCMEntity asString ].
 	theCellViews
 		@ popUp;
 		when: RSMouseLeftClick do: [ : aRSMouseClick | aRSMouseClick shape model inspect ].


### PR DESCRIPTION
Defined a default asString method for entities which will be displaye…d when the user hover the cells in the visualization space.

Also defined customized asString method for some models with interesting state to be shown.
Removed the #asPopupText references and methods.