### PR TITLE
Multiple issues inherited from GitBridge and CI testing

### DIFF
--- a/repository/Cormas-Core/CMModel2ProjectMigrator.class.st
+++ b/repository/Cormas-Core/CMModel2ProjectMigrator.class.st
@@ -32,6 +32,24 @@ CMModel2ProjectMigrator class >> migrateModels [
 			moveProjects ]
 ]
 
+{ #category : #defaults }
+CMModel2ProjectMigrator class >> resourceDirectoryNames [
+	" Answer a <Collection> with the names of subdirectories of a CORMAS project "
+
+	^ #(
+		'animations'
+		'diagrams' 
+		'doc' 
+		'dumps' 
+		'images'
+		'inputs'
+		'maps'
+		'old_versions'
+		'outputs'
+		'video'
+		)
+]
+
 { #category : #building }
 CMModel2ProjectMigrator >> buildForModel: aCMProjectModel [
 	" Creates a CORMAS project file, answer a <FileReference> to the new created project "
@@ -245,18 +263,7 @@ CMModel2ProjectMigrator >> outputDirectory [
 CMModel2ProjectMigrator >> resourceDirectoryNames [
 	" Answer a <Collection> with the names of subdirectories of a CORMAS project "
 
-	^ #(
-		'animations'
-		'diagrams' 
-		'doc' 
-		'dumps' 
-		'images'
-		'inputs'
-		'maps'
-		'old_versions'
-		'outputs'
-		'video'
-		)
+	^ self class resourceDirectoryNames
 ]
 
 { #category : #defaults }

--- a/repository/Cormas-Core/CMResourceCreator.class.st
+++ b/repository/Cormas-Core/CMResourceCreator.class.st
@@ -22,15 +22,6 @@ CMResourceCreator >> animationsPath [
 ]
 
 { #category : #'utilities - path - models' }
-CMResourceCreator >> dataPath: aModelClassName [
-	" Answer a <FileReference> corresponding to the path of the current model 'data' directory.
-	aModelClassName = <String>"
-	
-	^ (super dataPath: aModelClassName) ensureCreateDirectory.
-
-]
-
-{ #category : #'utilities - path - models' }
 CMResourceCreator >> dumpPath: aModelClassName [
 	" Answer a <FileReference> corresponding to the path of the current model 'dump' directory.
 	aModelClassName = <String>"

--- a/repository/Cormas-Core/CMResourceLocator.class.st
+++ b/repository/Cormas-Core/CMResourceLocator.class.st
@@ -17,6 +17,9 @@ Internal Representation and Key Implementation Points.
 Class {
 	#name : #CMResourceLocator,
 	#superclass : #GitBridge,
+	#classInstVars : [
+		'useGitBridge'
+	],
 	#category : #'Cormas-Core-Kernel'
 }
 
@@ -31,7 +34,23 @@ CMResourceLocator class >> assetsFilesDirectoryName [
 CMResourceLocator class >> assetsPath [
 	"Return the assets path of Cormas
 	Ex: {localDirectory}/iceberg/cormas/cormas/assets"
-	
+
+	^ self useGitBridge
+		ifTrue: [ self assetsPathForIceberg ]
+		ifFalse: [ self assetsPathForCI ]
+
+]
+
+{ #category : #accessing }
+CMResourceLocator class >> assetsPathForCI [
+	" The model path from the resource already contains the assets directory "
+
+	^ CMModelResource current modelPath
+]
+
+{ #category : #accessing }
+CMResourceLocator class >> assetsPathForIceberg [
+
 	^ ([ self root ]
 		on: GBError
 		do: [ :ex | FileLocator workingDirectory ]) / self assetsFilesDirectoryName
@@ -63,6 +82,20 @@ CMResourceLocator class >> preferencesPath [
 ]
 
 { #category : #accessing }
+CMResourceLocator class >> useGitBridge [
+	" Read comment in #root method "
+
+	^ useGitBridge
+		ifNil: [ useGitBridge := true ]
+]
+
+{ #category : #accessing }
+CMResourceLocator class >> useGitBridge: anObject [
+
+	useGitBridge := anObject
+]
+
+{ #category : #accessing }
 CMResourceLocator class >> userProjectsPath [
 	" Answer a <FileReference> with the receiver's path to the user projects directory "
 
@@ -76,7 +109,7 @@ CMResourceLocator class >> workingDirectory [
 	^ FileSystem disk workingDirectory fullName
 ]
 
-{ #category : #'utilities - path' }
+{ #category : #'utilities - path - global' }
 CMResourceLocator >> addOnsPath [
 	" Answer a <FileReference> corresponding to the path of 'Add-ons' directory "
 	
@@ -85,7 +118,7 @@ CMResourceLocator >> addOnsPath [
 
 ]
 
-{ #category : #'utilities - path' }
+{ #category : #'utilities - path - models' }
 CMResourceLocator >> animationsPath: shortModelName [
 	" Answer a <FileReference> corresponding to the path of stored Animations directory. "
 
@@ -102,14 +135,14 @@ CMResourceLocator >> assetNamed: aFilename [
 
 ]
 
-{ #category : #'utilities - path' }
+{ #category : #'utilities - path - global' }
 CMResourceLocator >> assetsFilesDirectoryName [
 	" Answe a <String> with the name of the directoy where CORMAS resources are found "
 
 	^ self class assetsFilesDirectoryName
 ]
 
-{ #category : #'utilities - path' }
+{ #category : #'utilities - path - global' }
 CMResourceLocator >> assetsPath [
 	" Answer a <FileReference> specifying a directory where CORMAS assets are found.
 	Ex: /Users/Bommel/Pharo/images/Pharo 8.0 - 64bit (stable)/pharo-local/iceberg/cormas/cormas/assets"
@@ -117,7 +150,7 @@ CMResourceLocator >> assetsPath [
 	^ self class assetsPath asFileReference
 ]
 
-{ #category : #'utilities - path' }
+{ #category : #'utilities - path - global' }
 CMResourceLocator >> cormasPath [
 	" Answer a <FileReference> corresponding to the path of Cormas directory. "
 
@@ -126,11 +159,20 @@ CMResourceLocator >> cormasPath [
 ]
 
 { #category : #'utilities - path - models' }
-CMResourceLocator >> dataPath: aModelClassName [
-	" Answer a <FileReference> corresponding to the path of the current model 'data' directory.
+CMResourceLocator >> diagramsPath: aModelClassName [
+	" Answer a <FileReference> corresponding to the path of the current model 'dump' directory.
 	aModelClassName = <String>"
 	
-	^ (self modelPath: aModelClassName) / 'data'.
+	^ (self modelPath: aModelClassName) / 'diagrams'.
+
+]
+
+{ #category : #'utilities - path - models' }
+CMResourceLocator >> docPath: aModelClassName [
+	" Answer a <FileReference> corresponding to the path of the current model 'doc' directory.
+	aModelClassName = <String>"
+	
+	^ (self modelPath: aModelClassName) / 'doc'.
 
 ]
 
@@ -143,7 +185,7 @@ CMResourceLocator >> dumpPath: aModelClassName [
 
 ]
 
-{ #category : #'utilities - path' }
+{ #category : #'utilities - path - global' }
 CMResourceLocator >> imagesPath [
 	" Answer a <FileReference> corresponding to the path of the current 'images' directory.
 	aModelClassName = <String>"
@@ -153,6 +195,24 @@ CMResourceLocator >> imagesPath [
 ]
 
 { #category : #'utilities - path - models' }
+CMResourceLocator >> imagesPath: shortModelName [
+	" Answer a <FileReference> corresponding to the path of the images directory of shortModelName.
+	Argument: shortModelName = <String>	"
+	
+	^ (self modelPath: shortModelName) asFileReference / 'images'.
+
+]
+
+{ #category : #'utilities - path - models' }
+CMResourceLocator >> inputsPath: aModelClassName [
+	" Answer a <FileReference> corresponding to the path of the current model 'inputs' directory.
+	aModelClassName = <String>"
+	
+	^ (self modelPath: aModelClassName) / 'inputs'.
+
+]
+
+{ #category : #'utilities - path - global' }
 CMResourceLocator >> mapsPath [
 	" Answer a FileReference corresponding to the path of the current path directory.
 	Argument: aModelClassName = <String>
@@ -204,6 +264,24 @@ CMResourceLocator >> modelsPath [
 
 ]
 
+{ #category : #'utilities - path - models' }
+CMResourceLocator >> oldVersionsPath: aModelClassName [
+	" Answer a <FileReference> corresponding to the path of the current model 'old_versions' directory.
+	aModelClassName = <String>"
+	
+	^ (self modelPath: aModelClassName) / 'old_versions'.
+
+]
+
+{ #category : #'utilities - path - models' }
+CMResourceLocator >> outputsPath: aModelClassName [
+	" Answer a <FileReference> corresponding to the path of the current model 'outputs' directory.
+	aModelClassName = <String>"
+	
+	^ (self modelPath: aModelClassName) / 'outputs'.
+
+]
+
 { #category : #'utilities - csv' }
 CMResourceLocator >> readCsv: filename [
 	"
@@ -235,7 +313,7 @@ The file name is just a string containing the name of the file (with or without 
 		ifEmpty: [ fileName := file , '.csv' ]
 		ifNotEmpty: [ fileName := file ].	
 	^ self
-		readMatrix: ((self dataPath: modelName) / fileName) fullName
+		readMatrix: ((self inputsPath: modelName) / fileName) fullName
 		sep: DataSaver_Asci separator
 ]
 
@@ -294,7 +372,7 @@ CMResourceLocator >> videoPath: aModelClassName [
 
 ]
 
-{ #category : #'utilities - path' }
+{ #category : #'utilities - path - global' }
 CMResourceLocator >> workingDirectory [
 	" Answer a <String> representing the current working directory "
 	

--- a/repository/Cormas-Tests/CMModelResource.class.st
+++ b/repository/Cormas-Tests/CMModelResource.class.st
@@ -1,0 +1,90 @@
+Class {
+	#name : #CMModelResource,
+	#superclass : #TestResource,
+	#instVars : [
+		'modelPath'
+	],
+	#category : #'Cormas-Tests-Helpers'
+}
+
+{ #category : #running }
+CMModelResource >> buildCormasAssetsHierarchy [
+	" Build the skeleton for the assets directory in CORMAS for testing purposes "
+
+	{ 
+		{'common'} .
+		{'icons'} .
+		{'images'} .
+		{'installer'} .
+		{'logos'} .
+		{ 'models' . self sampleModelName } } do: [ : d | 
+  			d
+				inject: self modelPath
+				into: [ : acc : cmDir | (acc / cmDir) asFileReference ensureCreateDirectory ] ].
+]
+
+{ #category : #running }
+CMModelResource >> buildCormasModelHierarchyFor: aModelName [
+	" Answer a <Collection> with the subdirectories of a single CORMAS model "
+
+	| baseModelDir |
+	baseModelDir := self modelPath / 'models' / aModelName.
+	self cormasModelHierarchy do: [ : d | 
+  		d
+			inject: baseModelDir
+			into: [ : acc : cmDir | (acc / cmDir) asFileReference ensureCreateDirectory ] ].
+]
+
+{ #category : #running }
+CMModelResource >> cormasModelHierarchy [
+
+	^ (CMModel2ProjectMigrator resourceDirectoryNames) collect: [ : each | { each } ]
+
+]
+
+{ #category : #accessing }
+CMModelResource >> modelPath [
+
+	^ modelPath
+]
+
+{ #category : #accessing }
+CMModelResource >> modelPath: anObject [
+
+	modelPath := anObject
+]
+
+{ #category : #running }
+CMModelResource >> sampleModelName [
+
+	^ 'MockModel'
+]
+
+{ #category : #running }
+CMModelResource >> setUp [
+
+	super setUp.
+	self setUpPathReferences
+]
+
+{ #category : #running }
+CMModelResource >> setUpPathReferences [
+	" Create a sample directory structure for a mock model "
+
+	self modelPath: FileSystem memory root / CMResourceLocator assetsFilesDirectoryName.
+	self modelPath createDirectory.
+	self 
+		buildCormasAssetsHierarchy;
+		buildCormasModelHierarchyFor: self sampleModelName.
+	
+]
+
+{ #category : #running }
+CMModelResource >> tearDown [
+
+	[ self modelPath ensureDeleteAll ]
+	on: FileDoesNotExistException
+	do: [ : ex | ].	
+	CMResourceLocator useGitBridge: true.
+	super tearDown.
+]

--- a/repository/Cormas-Tests/CMResourceLocatorTest.class.st
+++ b/repository/Cormas-Tests/CMResourceLocatorTest.class.st
@@ -2,36 +2,92 @@ Class {
 	#name : #CMResourceLocatorTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'instance'
+		'resourceLocator',
+		'resourceBuilder'
 	],
 	#category : #'Cormas-Tests-Helpers'
 }
 
 { #category : #accessing }
-CMResourceLocatorTest >> instance [
-	^ instance
+CMResourceLocatorTest class >> resources [
+
+	^ Array with: CMModelResource.
 ]
 
 { #category : #accessing }
-CMResourceLocatorTest >> instance: arg1 [
-	instance := arg1
+CMResourceLocatorTest >> resourceBuilder [
+
+	^ CMModelResource current
+]
+
+{ #category : #accessing }
+CMResourceLocatorTest >> resourceLocator [
+	^ resourceLocator
+]
+
+{ #category : #accessing }
+CMResourceLocatorTest >> resourceLocator: arg1 [
+	resourceLocator := arg1
+]
+
+{ #category : #testing }
+CMResourceLocatorTest >> sampleMatrixContents [
+
+	^ '1;2;10
+2;0;0
+3;3;4
+4;3;8
+5;2;2
+6;3;5
+7;3;10
+8;3;5
+9;2;2
+10;3;5'
+]
+
+{ #category : #testing }
+CMResourceLocatorTest >> sampleMatrixFile [
+
+	| tempFilename |
+	
+	tempFilename := self tempFileFor: 'sampleMatrix' suffix: '.csv'.
+	tempFilename asFileReference writeStreamDo: [ : stream | stream nextPutAll: self sampleMatrixContents ].
+	^ tempFilename
 ]
 
 { #category : #accessing }
 CMResourceLocatorTest >> sampleModel [
-	^ 'ECEC'
+
+	^ self resourceBuilder modelPath 
 ]
 
-{ #category : #testing }
+{ #category : #accessing }
+CMResourceLocatorTest >> sampleModelName [
+	" Answer a <String> with the name of the mock model used for testing "
+
+	^ self resourceBuilder sampleModelName 
+]
+
+{ #category : #running }
 CMResourceLocatorTest >> setUp [
+
 	super setUp.
-	self instance: CMResourceLocator new
+	self resourceLocator: CMResourceLocator new.
+	self resourceLocator class useGitBridge: false.
+]
+
+{ #category : #accessing }
+CMResourceLocatorTest >> tempFileFor: aName suffix: aSuffixString [
+
+	^ (FileLocator temp asFileReference
+		/ (FileReference newTempFilePrefix: aName suffix: aSuffixString) basename)
+		fullName
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testAnimationsPath [
 	| cmFileRef |
-	cmFileRef := self instance animationsPath: self sampleModel.
+	cmFileRef := self resourceLocator animationsPath: self sampleModelName.
 	self
 		assert: (cmFileRef isKindOf: FileReference);
 		assert: cmFileRef isDirectory 
@@ -40,69 +96,101 @@ CMResourceLocatorTest >> testAnimationsPath [
 { #category : #testing }
 CMResourceLocatorTest >> testAssetNamed [
 
-	self assert: ((self instance assetNamed: 'simpleMap.csv') isKindOf: FileReference)
+	self assert: ((self resourceLocator assetNamed: 'simpleMap.csv') isKindOf: FileReference)
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testAssetsFilesDirectoryName [
 
-	self assert: (self instance assetsFilesDirectoryName isKindOf: String).
-	self deny: self instance assetsFilesDirectoryName isEmpty 
+	self assert: (self resourceLocator assetsFilesDirectoryName isKindOf: String).
+	self deny: self resourceLocator assetsFilesDirectoryName isEmpty 
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testAssetsPath [
 
-	self assert: (self instance assetsPath isKindOf: FileReference).
-	self assert: self instance assetsPath isDirectory.
+	self assert: (self resourceLocator assetsPath isKindOf: FileReference).
+	self assert: self resourceLocator assetsPath isDirectory.
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testCormasPath [
-	self assert: (self instance cormasPath isKindOf: FileReference)
+	self assert: (self resourceLocator cormasPath isKindOf: FileReference)
 ]
 
 { #category : #testing }
-CMResourceLocatorTest >> testDataPath [
+CMResourceLocatorTest >> testDiagramsPath [
+
 	| cmFileRef |
-	cmFileRef := self instance dataPath: self sampleModel.
+	
+	cmFileRef := self resourceLocator diagramsPath: self sampleModelName.
 	self
 		assert: (cmFileRef isKindOf: FileReference);
-		assert: cmFileRef isDirectory 
+		assert: cmFileRef isDirectory;
+		assert: cmFileRef fullName equals: '/assets/models/MockModel/diagrams'
+]
+
+{ #category : #testing }
+CMResourceLocatorTest >> testDocPath [
+
+	| cmFileRef |
+	
+	cmFileRef := self resourceLocator docPath: self sampleModelName.
+	self
+		assert: (cmFileRef isKindOf: FileReference);
+		assert: cmFileRef isDirectory;
+		assert: cmFileRef fullName equals: '/assets/models/MockModel/doc'
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testDumpPath [
 	| cmFileRef |
-	cmFileRef := self instance dumpPath: self sampleModel.
+	cmFileRef := self resourceLocator dumpPath: self sampleModelName.
 	self
 		assert: (cmFileRef isKindOf: FileReference);
-		assert: cmFileRef isDirectory 
+		assert: cmFileRef isDirectory;
+		assert: cmFileRef fullName equals: '/assets/models/MockModel/dumps'
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testImagesPath [
 
 	| cmFileRef |
-	cmFileRef := self instance imagesPath.
+	
+	cmFileRef := self resourceLocator imagesPath: self sampleModelName.
 	self assert: (cmFileRef isKindOf: FileReference).
+	self assert: cmFileRef isDirectory.
+	self assert: cmFileRef fullName equals: '/assets/models/MockModel/images'
+]
+
+{ #category : #testing }
+CMResourceLocatorTest >> testInputsPath [
+	| cmFileRef |
+	cmFileRef := self resourceLocator inputsPath: self sampleModelName.
+	self
+		assert: (cmFileRef isKindOf: FileReference);
+		assert: cmFileRef isDirectory;
+		assert: cmFileRef fullName equals: '/assets/models/MockModel/inputs'
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testMapsPath [
+
 	| cmFileRef |
-	cmFileRef := self instance mapsPath: self sampleModel.
+	
+	cmFileRef := self resourceLocator mapsPath: self sampleModelName.
 	self
 		assert: (cmFileRef isKindOf: FileReference);
-		assert: cmFileRef isDirectory 
+		assert: cmFileRef isDirectory;
+		assert: cmFileRef fullName equals: '/assets/models/MockModel/maps'
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testModelNames [
 
-	self assert: (self instance modelNames isKindOf: Collection).
-	self deny: self instance modelNames isEmpty.
-	self assert: (self instance modelNames anyOne isKindOf: String)
+	self assert: (self resourceLocator modelNames isKindOf: Collection).
+	self deny: self resourceLocator modelNames isEmpty.
+	self assert: (self resourceLocator modelNames anyOne isKindOf: String)
 
 ]
 
@@ -110,15 +198,40 @@ CMResourceLocatorTest >> testModelNames [
 CMResourceLocatorTest >> testModelPath [
 
 	| cmFileRef |
-	cmFileRef := self instance modelPath: self sampleModel.
+	cmFileRef := self resourceLocator modelPath: self sampleModelName.
 	self
-		assert: (cmFileRef isKindOf: FileReference).
+		assert: (cmFileRef isKindOf: FileReference);
+		assert: cmFileRef fullName equals: '/assets/models/MockModel'
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testModelsPath [
 
-	self assert: (self instance modelsPath isKindOf: FileReference).
+	self 
+		assert: (self resourceLocator modelsPath isKindOf: FileReference);
+		assert: self resourceLocator modelsPath fullName equals: '/assets/models'
+]
+
+{ #category : #testing }
+CMResourceLocatorTest >> testOldVersionsPath [
+
+	| cmFileRef |
+	
+	cmFileRef := self resourceLocator oldVersionsPath: self sampleModelName.
+	self
+		assert: (cmFileRef isKindOf: FileReference);
+		assert: cmFileRef isDirectory;
+		assert: cmFileRef fullName equals: '/assets/models/MockModel/old_versions'
+]
+
+{ #category : #testing }
+CMResourceLocatorTest >> testOutputsPath [
+	| cmFileRef |
+	cmFileRef := self resourceLocator outputsPath: self sampleModelName.
+	self
+		assert: (cmFileRef isKindOf: FileReference);
+		assert: cmFileRef isDirectory;
+		assert: cmFileRef fullName equals: '/assets/models/MockModel/outputs'
 ]
 
 { #category : #testing }
@@ -126,7 +239,9 @@ CMResourceLocatorTest >> testReadCsvFileMyModel [
 
 	| matrix |
 	
-	matrix := self instance readCsvFile: 'simpleMap' myModel: 'ECEC'.
+	matrix := self resourceLocator 
+		readCsvFile: self sampleMatrixFile 
+		myModel: self sampleModelName.
 	self assert: (matrix isKindOf: Collection).
 	self deny: matrix isEmpty.
 	self assert: (matrix allSatisfy: [ : subCol | subCol isKindOf: Collection ]).
@@ -138,25 +253,26 @@ CMResourceLocatorTest >> testReadMatrixSep [
 
 	| matrix |
 	
-	matrix := self instance
-		readMatrix: ((self instance dataPath: self sampleModel) / 'simpleMap.csv') fullName
-		sep: $;.
+	matrix := self resourceLocator readMatrix: self sampleMatrixFile sep: $;.
 	self assert: (matrix isKindOf: Collection).
-	self assert: (matrix anyOne isKindOf: Collection)
+	self assert: (matrix anyOne isKindOf: Collection).
+	self assert: matrix size equals: 10.
+	self assert: (matrix allSatisfy: [ : arr | arr size = 3 ]).
 	
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testVideoPath [
 	| cmFileRef |
-	cmFileRef := self instance videoPath: self sampleModel.
+	cmFileRef := self resourceLocator videoPath: self sampleModelName.
 	self
 		assert: (cmFileRef isKindOf: FileReference);
-		assert: cmFileRef isDirectory
+		assert: cmFileRef isDirectory;
+		assert: cmFileRef fullName equals: '/assets/models/MockModel/video'
 ]
 
 { #category : #testing }
 CMResourceLocatorTest >> testWorkingDirectory [
 
-	self assert: (self instance workingDirectory isKindOf: String) 
+	self assert: (self resourceLocator workingDirectory isKindOf: String) 
 ]


### PR DESCRIPTION
Completed missing methods for accessing resource paths.
Implemented assetsPathForCI and assetsPathForIceberg since CI does not use Iceberg
Add CMModelResource test resource class to build an assets hierarchy for testing purposes.
Add resource locator tests
Remove #dataPath: since not we use #inputPath: and #outputPath: