### PR TITLE
allow capitalized repository name, e.g. ."Cormas".

### DIFF
--- a/repository/Cormas-Core/CMApplicationProject.class.st
+++ b/repository/Cormas-Core/CMApplicationProject.class.st
@@ -68,7 +68,7 @@ CMApplicationProject class >> cormasRepository [
 	" Answer the receiver's CORMAS Iceberg repository  "
 
 	^ IceLibgitRepository registry 
-		detect: [ : repo | repo name = 'cormas' ]
+		detect: [ : repo | repo name asLowercase = 'cormas' ]
 		ifNone: [ nil ]
 ]
 


### PR DESCRIPTION
solves https://github.com/cormas/cormas/issues/587