### PR TITLE
Salvage CMAgentLocation for compatibility

### DIFF
--- a/repository/Cormas-Core/CMAgentLocation.class.st
+++ b/repository/Cormas-Core/CMAgentLocation.class.st
@@ -3,23 +3,3 @@ Class {
 	#superclass : #CMLocatedAgent,
 	#category : #'Cormas-Core-Compatibility'
 }
-
-{ #category : #'subclass creation' }
-CMAgentLocation class >> subclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s package: cat [
-
-	^ self = CMAgentLocation
-		  ifTrue: [ 
-			  CMLocatedAgent
-				  subclass: t
-				  instanceVariableNames: f
-				  classVariableNames: d
-				  poolDictionaries: s
-				  package: cat ]
-		  ifFalse: [ 
-			  super
-				  subclass: t
-				  instanceVariableNames: f
-				  classVariableNames: d
-				  poolDictionaries: s
-				  package: cat ]
-]

--- a/repository/Cormas-Core/CMAgentLocation.class.st
+++ b/repository/Cormas-Core/CMAgentLocation.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #CMAgentLocation,
+	#superclass : #CMLocatedAgent,
+	#category : #'Cormas-Core-Compatibility'
+}
+
+{ #category : #'subclass creation' }
+CMAgentLocation class >> subclass: t instanceVariableNames: f classVariableNames: d poolDictionaries: s package: cat [
+
+	^ self = CMAgentLocation
+		  ifTrue: [ 
+			  CMLocatedAgent
+				  subclass: t
+				  instanceVariableNames: f
+				  classVariableNames: d
+				  poolDictionaries: s
+				  package: cat ]
+		  ifFalse: [ 
+			  super
+				  subclass: t
+				  instanceVariableNames: f
+				  classVariableNames: d
+				  poolDictionaries: s
+				  package: cat ]
+]


### PR DESCRIPTION
Without CMAgentLocation, most models can't be loaded. CMAgentLocation will be defined as a subclass of CMLocatedAgent.