### PR TITLE
[Feature]:"Ask before reinitializing" option unchecked by default

### DIFF
--- a/src/Cormas-UI/CMSimulationInitializerPresenter.class.st
+++ b/src/Cormas-UI/CMSimulationInitializerPresenter.class.st
@@ -127,7 +127,7 @@ CMSimulationInitializerPresenter >> initializePresenters [
 		
 	shouldWarnWhenReinitializeCheckbox := self newCheckBox
 		label: 'Ask before reinitializing';
-		state: true;
+		state: false;
 		yourself.
 	
 	initializeButton := self newButton


### PR DESCRIPTION
Fixes #781 

Unchecked the "Ask before reinitializing" button by updating CMSimulationInitializerPresenter >> initializePresenters and changing the default state from true to false.