### PR TITLE
build-script generator for standalone cormas image

### DIFF
--- a/src/BaselineOfCormas/BaselineOfCormas.class.st
+++ b/src/BaselineOfCormas/BaselineOfCormas.class.st
@@ -93,7 +93,11 @@ BaselineOfCormas >> specForBaselines: spec [
 		
 	spec
 		baseline: 'RoassalExporters'
-		with: [ spec repository: 'github://pharo-graphics/RoassalExporters:v1.02' ]
+		with: [ spec repository: 'github://pharo-graphics/RoassalExporters:v1.02' ].
+
+	spec
+		baseline: 'Phleeter'
+		with: [ spec repository: 'github://tomooda/Phleeter:main/src' ].
 
 ]
 
@@ -113,7 +117,8 @@ BaselineOfCormas >> specForGroups: spec [
 			'Cormas-UI-Tilesets'
 			'Cormas-SensitivityAnalysis-Tests'
 			'Cormas-SensitivityAnalysis-UI-Tests');
-		group: 'default' with: #('SensitivityAnalysisUI')
+		group: 'default' with: #('SensitivityAnalysisUI');
+		group: 'deploy' with: #('default' 'Cormas-Application')
 ]
 
 { #category : 'specs' }
@@ -157,5 +162,8 @@ BaselineOfCormas >> specForPackages: spec [
 		with: [ spec requires: #('Cormas-SensitivityAnalysis' 'Cormas-Mocks' 'Cormas-UI-Translator') ];
 		
 		package: 'Cormas-SensitivityAnalysis-UI-Tests'
-		with: [ spec requires: #('Cormas-SensitivityAnalysis-UI') ].
+		with: [ spec requires: #('Cormas-SensitivityAnalysis-UI') ];
+
+		package: 'Cormas-Application'
+		with: [ spec requires: #('Phleeter') ].
 ]

--- a/src/Cormas-Application/CormasCommandLineHandler.class.st
+++ b/src/Cormas-Application/CormasCommandLineHandler.class.st
@@ -1,0 +1,101 @@
+Class {
+	#name : 'CormasCommandLineHandler',
+	#superclass : 'CommandLineHandler',
+	#category : 'Cormas-Application',
+	#package : 'Cormas-Application'
+}
+
+{ #category : 'accessing' }
+CormasCommandLineHandler class >> commandName [
+
+	^ 'cormas'
+]
+
+{ #category : 'icons' }
+CormasCommandLineHandler class >> cormasIcon [
+
+	| icon m left right top bottom r logo |
+	icon := Form extent: 128 @ 128 depth: 32.
+	m := 4.
+	left := 4.
+	right := 128 - 4.
+	top := 4.
+	bottom := 128 - 4.
+	r := 32.
+	icon getCanvas
+		fillColor: Color transparent;
+		fillRectangle: (left + r @ top corner: right - r @ bottom)
+		color: Color white;
+		fillRectangle: (left @ (top + r) corner: right @ (bottom - r))
+		color: Color white;
+		fillOval: (left @ top extent: r @ r * 2) color: Color white;
+		fillOval: (right - r - r @ top extent: r @ r * 2)
+		color: Color white;
+		fillOval: (left @ (bottom - r - r) extent: r @ r * 2)
+		color: Color white;
+		fillOval: (right - r - r @ (bottom - r - r) extent: r @ r * 2)
+		color: Color white.
+	logo := (BaselineOfCormas cormasLogo form contentsOfArea:
+		         (0 @ 0 extent: 400 @ 400)) scaledToSize: 124 @ 124.
+	icon getCanvas translucentImage: logo at: 4 @ -2.
+	^ icon
+]
+
+{ #category : 'translating' }
+CormasCommandLineHandler class >> generate [
+
+	<script: 'CormasCommandLineHandler generate'>
+	PhleeterOnOSX new
+		properties: {
+				(#AppName -> 'Cormas').
+				(#InfoString
+				 -> 'COmmon pool Ressources and Multi-Agent Simulations').
+				(#BundleIdentifier -> 'com.github.cormas.cormas').
+				(#ShortVersion -> '1.0.0').
+				(#DisplayName -> 'Cormas').
+				(#IconSetFile
+				 -> ((IceRepository repositoryNamed: 'cormas') location / 'icons'
+					  / 'Cormas.icns')).
+				(#DiskIconSetFile
+				 -> ((IceRepository repositoryNamed: 'cormas') location / 'icons'
+					  / 'Cormas.icns')).
+				(#DeployPharoExpression -> 'CormasCommandLineHandler deploy').
+				(#CommandLineHandler -> self commandName).
+				(#CompanyName -> 'Cormas project') } asDictionary;
+		targetPlatforms:
+			#( 'Darwin-arm64' 'Darwin-x86_64' 'Windows-x86_64' );
+		outputDirectory: FileLocator home / 'src' / 'Cormas' / 'build';
+		generate
+]
+
+{ #category : 'activation' }
+CormasCommandLineHandler >> activate [
+
+	self
+		installMenu;
+		installIcon
+]
+
+{ #category : 'initialization' }
+CormasCommandLineHandler >> installIcon [
+
+	self currentWorld worldState worldRenderer osWindow icon:
+		self class cormasIcon
+]
+
+{ #category : 'initialization' }
+CormasCommandLineHandler >> installMenu [
+
+	OSWindowDriver current startUp: true.
+	OSPlatform current isMacOSX ifTrue: [
+		| main |
+		main := CocoaMenu new.
+		main
+			title: 'MainMenu';
+			addSubmenu: 'Cormas' with: [ :m |
+				m
+					addItemWithTitle: 'Settings...'
+					action: [ SettingBrowser new open ];
+					addItemWithTitle: 'Quit' action: [ WorldState quitSession ] ].
+		main setAsMainMenu ]
+]

--- a/src/Cormas-Application/CormasCommandLineHandler.class.st
+++ b/src/Cormas-Application/CormasCommandLineHandler.class.st
@@ -41,7 +41,31 @@ CormasCommandLineHandler class >> cormasIcon [
 	^ icon
 ]
 
-{ #category : 'translating' }
+{ #category : 'utilities' }
+CormasCommandLineHandler class >> deploy [
+
+	<script>
+	MCRepositoryGroup allSubInstancesDo: [ :group |
+		group repositories do: [ :repo | group removeRepository: repo ] ].
+	IceRepository registry removeAll.
+	IceCredentialStore current in: [ :store |
+		store allCredentials do: [ :each | each removeFrom: store ] ].
+	self currentWorld closeAllWindowsDiscardingChanges.
+	Deprecation
+		raiseWarning: false;
+		showWarning: false.
+	NoChangesLog install.
+	"NoPharoFilesOpener install."
+	FFICompilerPlugin install.
+	Stdio useNullStreams.
+	MCCacheRepository uniqueInstance disable.
+	EpMonitor reset.
+	SessionManager default registerSystemClassNamed: #FreeTypeFileInfo.
+	5 timesRepeat: [ "PharoCommandLineHandler forcePreferencesOmission: true"
+		Smalltalk garbageCollect ]
+]
+
+{ #category : 'generating' }
 CormasCommandLineHandler class >> generate [
 
 	<script: 'CormasCommandLineHandler generate'>

--- a/src/Cormas-Application/package.st
+++ b/src/Cormas-Application/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Cormas-Application' }


### PR DESCRIPTION
To generate a build script for stand-alone cormas for macOS arm64/x86_64 and windows.

1. launch pharo on macOS.
2. Install the cormas with 'deploy' group.
3. evaluate `CormasCommandLineHandler generate` to generate build script in  ~/src/Cormas/build/ directory.
4. open a terminal and cd ~/src/Cormas/build.
5. execute `bash build.sh` to download vms and build a cormas image.
6. You'll find `Cormas-Installer-Darwin-arm64.dmg`, `Cormas-Installer-Darwin-x86_64.dmg` and `Cormas-Windows-x86_64.zip` in the directory.
7. On mac, open a dmg file to install `Cormas.app` to /Application. On Windows, unzip the zip file to your directory.
8. To change setups, e.g. cert name for codesign, edit `CormasCommandLineHandler>>generate`.