### PR TITLE
[Fixed] : "Create" button allows to choose agent is being created

### DIFF
--- a/src/Cormas-UI-Commands/CMCreateAgentCommand.class.st
+++ b/src/Cormas-UI-Commands/CMCreateAgentCommand.class.st
@@ -19,15 +19,23 @@ CMCreateAgentCommand >> actionWhenOff [
 
 { #category : 'action' }
 CMCreateAgentCommand >> actionWhenOn [
-
-	| agentClass |
+	| agentClasses selectedClass |
 	
-	agentClass := owner cormasModel class allEntityClasses
-		detect: [ :aClass | aClass isCormasAgentClass and: [ aClass subclasses isEmpty ] ].
+	agentClasses := (owner cormasModel class allEntityClasses 
+		select: [ :aClass | aClass isCormasAgentClass and: [ aClass subclasses isEmpty ] ]) asArray.
+	
+	selectedClass := UIManager default 
+		chooseFrom: (agentClasses collect: [:each | each name])
+		values: agentClasses
+		title: 'Create Agent'.
+		
+	selectedClass ifNil: [ ^ self ].
 	
 	owner spaceBuilder whenLeftClickOnCellDo: [ :cell |
-		owner cormasModel newEntity: agentClass locatedAt: cell.
+		| newAgent |
+		newAgent := owner cormasModel newEntity: selectedClass locatedAt: cell.
 		owner updateDiagram ].
+
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Fixes #783 

# When clicked "**Create**" button, a dialogue box pop-up containing list of agents to be created.

![image](https://github.com/user-attachments/assets/505ecc43-bad0-4030-986d-f075f00ff349)
