### PR TITLE
Fixed #831. Added a menu button to open Cormas website

### DIFF
--- a/src/Cormas-UI/CMModelOpenerPresenter.class.st
+++ b/src/Cormas-UI/CMModelOpenerPresenter.class.st
@@ -54,6 +54,14 @@ CMModelOpenerPresenter class >> menu00CormasOn: aBuilder [
 		action: [ self new open ];
 		order: 1.
 		
+	(aBuilder item: #CormasWebsite)
+		parent: #Cormas ;
+		label: 'Cormas website';
+		icon: (self iconNamed: #remote);
+		help: 'Open Cormas website in a web browser';
+		action: [ WebBrowser openOn: 'https://cormas.org' ];
+		order: 1.
+		
 	(aBuilder item: #ColorPicker)
 		parent: #Cormas ;
 		label: 'Color Picker';


### PR DESCRIPTION
Added menu button that redirects to Cormas website in browser

<img width="288" height="146" alt="Screenshot 2025-08-26 at 19 39 20" src="https://github.com/user-attachments/assets/3f2c9757-6b80-4eac-a0d8-3280acb6ee5e" />
