### PR TITLE
Store simulation process in a variable to be able to control it

### DIFF
--- a/src/Cormas-UI/CMSimulationRunnerPresenter.class.st
+++ b/src/Cormas-UI/CMSimulationRunnerPresenter.class.st
@@ -15,7 +15,7 @@ Class {
 		'spacePage',
 		'dataPage',
 		'chartsPage',
-		'shouldPause'
+		'simulationProcess'
 	],
 	#category : 'Cormas-UI',
 	#package : 'Cormas-UI'
@@ -161,6 +161,24 @@ CMSimulationRunnerPresenter >> hideSettings [
 	self fitDiagram
 ]
 
+{ #category : 'initialization' }
+CMSimulationRunnerPresenter >> initialize [
+
+	super initialize.
+		
+	simulationProcess := [ [
+		[ false ] whileFalse: [
+			displayEveryNumberPresenter number timesRepeat: [ simulation runStep ].
+			
+			[ self updateAfterStep ] onErrorDo: [ :error |
+				"An ugly hack to silence Roassal errors that are caused by parallel execution"
+				error asString = '#intersect: was sent to nil' ifFalse: [ error signal ] ].
+		
+			(Delay forMilliseconds: self speedInMilliseconds) wait ] ]
+		ensure: [ self beInPauseMode ] ].
+	simulationProcess := simulationProcess newProcess
+]
+
 { #category : 'public' }
 CMSimulationRunnerPresenter >> initializeCharts [
 
@@ -219,8 +237,6 @@ CMSimulationRunnerPresenter >> initializeNotebookPages [
 { #category : 'initialization' }
 CMSimulationRunnerPresenter >> initializePresenters [
 
-	shouldPause := false.
-
 	runButton := self newButton
 		             help: translator tRunButtonHelp;
 		             yourself.
@@ -258,7 +274,7 @@ CMSimulationRunnerPresenter >> initializeRunButtonWithPauseAction [
 
 	runButton
 		icon: CMIcons pauseIcon;
-		action: [ self shouldPause: true ]
+		action: [ self pauseSimulation ]
 ]
 
 { #category : 'initialization' }
@@ -293,39 +309,24 @@ CMSimulationRunnerPresenter >> initializeWithSimulation [
 	self initializeNotebookPages.
 ]
 
+{ #category : 'initialization' }
+CMSimulationRunnerPresenter >> pauseSimulation [
+
+	self beInPauseMode.
+	simulationProcess suspend
+]
+
 { #category : 'actions' }
 CMSimulationRunnerPresenter >> runSimulationUntilEnd [
 
 	self beInRunningMode.
-	
-	[ [ [ simulation currentTimeStep < simulation finalTimeStep and: [ shouldPause not ] ] whileTrue: [
-		(displayEveryNumberPresenter number min: (simulation finalTimeStep - simulation currentTimeStep))
-			timesRepeat: [ simulation runStep ].
-			
-		[ self updateAfterStep ] onErrorDo: [ :error |
-			"An ugly hack to silence Roassal errors that are caused by parallel execution"
-			error asString = '#intersect: was sent to nil'
-				ifFalse: [ error signal ] ].
-		
-		(Delay forMilliseconds: self speedInMilliseconds) wait ]
-	] ensure: [
-		shouldPause := false.
-		self beInPauseMode ].
- 
-	shouldPause := false.
-	self beInPauseMode ] fork.
+	simulationProcess resume
 ]
 
 { #category : 'accessing - model' }
 CMSimulationRunnerPresenter >> setModelBeforeInitialization: aTranslator [
 
 	translator := aTranslator
-]
-
-{ #category : 'accessing' }
-CMSimulationRunnerPresenter >> shouldPause: aBoolean [
-
-	shouldPause := aBoolean
 ]
 
 { #category : 'as yet unclassified' }


### PR DESCRIPTION
Now the simulation process, the one started in `CMSimulationRunnerPresenter` is stored in an instance variable. With this, we can control its lifecycle by sending the messages `resume` or `suspend`.

This PR also removes the instance variable `shouldPause` since it is no longer needed since now we store the process itself.

Fixes https://github.com/cormas/cormas/issues/866