### PR TITLE
Changin layout to be top to bottom

### DIFF
--- a/src/Cormas-UI/CMSimulationInitRandomPresenter.class.st
+++ b/src/Cormas-UI/CMSimulationInitRandomPresenter.class.st
@@ -67,10 +67,12 @@ CMSimulationInitRandomPresenter >> connectPresenters [
 CMSimulationInitRandomPresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
-		  spacing: 3;
 		  add: translator tGenerator expand: false;
+		  add: (self instantiate: SpNullPresenter) expand: false;
 		  add: randomSeedGeneratorDroplist expand: false;
+		  add: (self instantiate: SpNullPresenter) expand: false;
 		  add: translator tRandomSeed expand: false;
+		  add: (self instantiate: SpNullPresenter) expand: false;
 		  add: randomSeedInput expand: false;
 		  add: fixRandomSeedCheckbox expand: false;
 		  add: releaseRandomSeedCheckbox expand: false;

--- a/src/Cormas-UI/CMSimulationInitRandomPresenter.class.st
+++ b/src/Cormas-UI/CMSimulationInitRandomPresenter.class.st
@@ -65,24 +65,16 @@ CMSimulationInitRandomPresenter >> connectPresenters [
 
 { #category : 'layout' }
 CMSimulationInitRandomPresenter >> defaultLayout [
- 
+
 	^ SpBoxLayout newTopToBottom
-		spacing: 12;
-		add: (SpBoxLayout newLeftToRight
-			add: translator tGenerator width: 85;
-			add: randomSeedGeneratorDroplist;
-			yourself)
-		height: 25;
-		add: (SpBoxLayout newLeftToRight
-			add: translator tRandomSeed width: 85;
-			add: randomSeedInput;
-			yourself)
-		height: 25;
-		add: (SpBoxLayout newTopToBottom
-			add: fixRandomSeedCheckbox height: 15;
-			add: releaseRandomSeedCheckbox height: 15;
-			yourself);
-		yourself
+		  spacing: 3;
+		  add: translator tGenerator expand: false;
+		  add: randomSeedGeneratorDroplist expand: false;
+		  add: translator tRandomSeed expand: false;
+		  add: randomSeedInput expand: false;
+		  add: fixRandomSeedCheckbox expand: false;
+		  add: releaseRandomSeedCheckbox expand: false;
+		  yourself
 ]
 
 { #category : 'as yet unclassified' }

--- a/src/Cormas-UI/CMSimulationInitializationSettingsPresenter.class.st
+++ b/src/Cormas-UI/CMSimulationInitializationSettingsPresenter.class.st
@@ -77,7 +77,6 @@ CMSimulationInitializationSettingsPresenter >> defaultLayout [
 					add: controlSelectorDropList span: 2 @ 1 ].
 
 	^ SpBoxLayout newTopToBottom
-		  spacing: 12;
 		  add: gridLayout expand: true;
 		  yourself
 ]


### PR DESCRIPTION
The layout of the random init presenter cuts half of the name of the generators. See picture below. I propose to change the layout like that the generator names will be read.

Before:
<img width="318" height="334" alt="Capture d’écran 2025-11-25 à 10 52 07" src="https://github.com/user-attachments/assets/495c057d-70b2-4be2-9de7-497291a710fb" />

After:
<img width="265" height="237" alt="Capture d’écran 2025-11-25 à 10 59 37" src="https://github.com/user-attachments/assets/94a1e191-f4b0-459e-b169-6f1f39b13ae1" />
